### PR TITLE
Tabell

### DIFF
--- a/src/app/actions/meldekort.tsx
+++ b/src/app/actions/meldekort.tsx
@@ -1,12 +1,15 @@
 import { ActionType, createStandardAction } from 'typesafe-actions';
 import { AxiosError } from 'axios';
+import { SendtMeldekort } from '../types/meldekort';
 
 export enum MeldekortTypeKeys {
     API_KALL_FEILET = 'API_KALL_FEILET',
+    LEGG_TIL_INNSENDT_MELDEKORT = 'LEGG_TIL_INNSENDT_MELDEKORT'
 }
 
 export const MeldekortActions = {
     apiKallFeilet: createStandardAction(MeldekortTypeKeys.API_KALL_FEILET)<AxiosError>(),
+    leggTilInnsendtMeldekort: createStandardAction(MeldekortTypeKeys.LEGG_TIL_INNSENDT_MELDEKORT)<SendtMeldekort[]>()
 };
 
 export type MeldekortActionTypes = ActionType<typeof MeldekortActions>;

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -105,20 +105,15 @@ class App extends React.Component<Props> {
     }
 
     settMenypunkterBasertPaPerson = (person: Person, menypunkter: MenyPunkt[]) => {
-        console.log(menypunkter);
-        const personHarPapirMeldeform = (mp: MenyPunkt): boolean => (person.meldeform === MeldeForm.PAPIR)
-            && (mp.tittel === 'endreMeldeform') && (mp.disabled === true);
-        const personHarEtterregistrerteMeldekort = (mp: MenyPunkt): boolean =>  !isEmpty(person.etterregistrerteMeldekort)
-            && mp.tittel === 'etterregistrering' && (mp.disabled === true);
-        const menypunktliste = menypunkter
-            .map(menypunkt => {
-                if (personHarPapirMeldeform(menypunkt) || personHarEtterregistrerteMeldekort(menypunkt) ) {
-                    console.log(menypunkt.tittel, menypunkt.disabled);
-                    return { ...menypunkt, disabled: !menypunkt.disabled };
-                } else {
-                    return { ...menypunkt };
-                }
-            });
+        const menypunktliste = menypunkter.map(menypunkt => {
+            if (menypunkt.tittel === 'endreMeldeform') {
+                return {...menypunkt, disabled: person.meldeform !== MeldeForm.PAPIR};
+            } else if (menypunkt.tittel === 'etterregistrering') {
+                return {...menypunkt, disabled: isEmpty(person.etterregistrerteMeldekort)};
+            }
+            return menypunkt;
+        });
+
         this.props.settMenyPunkter(menypunktliste);
     }
 

--- a/src/app/components/header/header.tsx
+++ b/src/app/components/header/header.tsx
@@ -3,7 +3,7 @@ import HovedMeny from '../hovedMeny/hovedMeny';
 import MobilMeny from '../mobilMeny/mobilMeny';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
-import { Person } from '../../types/person';
+import { MeldeForm, Person } from '../../types/person';
 import { MenyActions } from '../../actions/meny';
 import { MenyPunkt } from '../../utils/menyConfig';
 import { MenyState } from '../../types/meny';
@@ -12,6 +12,8 @@ import { Router } from '../../types/router';
 import { selectRouter } from '../../selectors/router';
 import { Sidetittel } from 'nav-frontend-typografi';
 import MobilMenyToggle from '../mobilMeny/mobilMenyToggle';
+import { useEffect, useState } from 'react';
+import { isEmpty } from 'ramda';
 
 interface MapStateToProps {
     router: Router;
@@ -32,7 +34,24 @@ type HeaderProps = MapStateToProps & MapDispatchToProps & BannerProps;
 
 const Header: React.FunctionComponent<HeaderProps> = (props) => {
 
-    const {router, meny} = props;
+    const {router, meny, person} = props;
+    const [oppdaterMeny, settMeny] = useState(meny.alleMenyPunkter);
+
+    const oppdatertMeny = meny.alleMenyPunkter.map(menypunkt => {
+        if (menypunkt.tittel === 'endreMeldeform') {
+            return {...menypunkt, disabled: person.meldeform !== MeldeForm.PAPIR};
+        } else if (menypunkt.tittel === 'etterregistrering') {
+            return {...menypunkt, disabled: isEmpty(person.etterregistrerteMeldekort)};
+        }
+        return menypunkt;
+    });
+
+    useEffect(() => {
+            props.settMenyPunkter(oppdatertMeny);
+        },
+              [oppdaterMeny]
+    );
+
     const params = router.location.pathname.split('/');
     const harPathInnsending = params[params.length - 2] === 'innsending' || params[params.length - 2] === 'korrigering' ;
     const headerClass = harPathInnsending ? 'meldekort-header__innsending' : 'meldekort-header';

--- a/src/app/components/knapp/navKnapp.tsx
+++ b/src/app/components/knapp/navKnapp.tsx
@@ -14,12 +14,14 @@ import { AktivtMeldekortActions } from '../../actions/aktivtMeldekort';
 interface MapStateToProps {
     router: Router;
     innsendingstypeFraStore: Innsendingstyper | null;
+    aktivtMeldekort: Meldekort;
 }
 
 interface MapDispatchToProps {
     leggTilAktivtMeldekort: (meldekort: Meldekort) => void;
     settInnsendingstype: (innsendingstype: Innsendingstyper) => void;
     resetInnsending: () => void;
+    leggTilMeldekortId: (meldekortId: number) => void;
 }
 
 interface NavKnappProps {
@@ -72,6 +74,7 @@ class NavKnapp extends React.Component<Props> {
                 validert = this.props.validering();
             }
             if (validert) {
+                console.log('Validert!')
                 const path = router.location.pathname;
                 const params = path.split('/');
                 const nestePathParams = nestePath.split('/');
@@ -83,11 +86,15 @@ class NavKnapp extends React.Component<Props> {
                     if (!erPaKvittering) {
                         nyPath = this.returnerNestePathInnenforInnsending(params, nestePathParams);
                     } else {
+                        this.props.resetInnsending();
                         nyPath = nestePath;
+                        if (this.harNestePathInnsending(nestePathParams) && nesteInnsendingstype !== undefined && typeof nesteAktivtMeldekort !== 'undefined') {
+                            this.props.leggTilMeldekortId(nesteAktivtMeldekort.meldekortId);
+                        }
                     }
-                } else {
-                    (this.harNestePathInnsending(nestePathParams) && nesteInnsendingstype !== undefined)
-                    && this.props.settInnsendingstype(nesteInnsendingstype);
+                }
+                if (this.harNestePathInnsending(nestePathParams) && nesteInnsendingstype !== undefined) {
+                    this.props.settInnsendingstype(nesteInnsendingstype);
                     nyPath = nestePath;
                 }
                 history.push(nyPath);
@@ -114,6 +121,7 @@ const mapStateToProps = (state: RootState): MapStateToProps => {
     return {
         router: selectRouter(state),
         innsendingstypeFraStore: state.innsending.innsendingstype,
+        aktivtMeldekort: state.aktivtMeldekort
     };
 };
 
@@ -123,7 +131,9 @@ const mapDispatchToProps = (dispatch: Dispatch): MapDispatchToProps => {
             dispatch(AktivtMeldekortActions.oppdaterAktivtMeldekort(aktivtMeldekort)),
         settInnsendingstype: (innsendingstype: Innsendingstyper) =>
             dispatch(InnsendingActions.leggTilInnsendingstype(innsendingstype)),
-        resetInnsending: () => dispatch(InnsendingActions.resetInnsending())
+        resetInnsending: () => dispatch(InnsendingActions.resetInnsending()),
+        leggTilMeldekortId: (meldekortId: number) =>
+            dispatch(InnsendingActions.leggTilMeldekortId(meldekortId))
     };
 };
 

--- a/src/app/components/komponentlenke/komponentlenke.tsx
+++ b/src/app/components/komponentlenke/komponentlenke.tsx
@@ -3,7 +3,6 @@ import 'nav-frontend-lenker-style';
 import { history, RootState } from '../../store/configureStore';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
-import { AktivtMeldekortState } from '../../reducers/aktivtMeldekortReducer';
 import { selectRouter } from '../../selectors/router';
 import { Router } from '../../types/router';
 import { Meldekort } from '../../types/meldekort';
@@ -17,7 +16,7 @@ interface KomponentlenkeProps {
 }
 
 interface MapStateToProps {
-    aktivtMeldekort: AktivtMeldekortState;
+    aktivtMeldekort: Meldekort;
     router: Router;
 }
 
@@ -49,8 +48,8 @@ class Komponentlenke extends React.Component<ReduxType> {
 }
 
 const mapStateToProps = (state: RootState): MapStateToProps => {
-        let meldekort: AktivtMeldekortState = {
-            meldekort: state.aktivtMeldekort.meldekort
+        let meldekort: Meldekort = {
+            ...state.aktivtMeldekort
         };
         return {
             aktivtMeldekort: meldekort,

--- a/src/app/components/meldekortdetaljer/meldekortdetaljer.tsx
+++ b/src/app/components/meldekortdetaljer/meldekortdetaljer.tsx
@@ -146,9 +146,9 @@ const Meldekortdetaljer: React.FunctionComponent<Props> = (props) => {
 
         let uke: string = '';
         if (ukeNr === 1) {
-            uke = hentNummerOgDatoForForsteUke(props.aktivtMeldekort.meldekort.meldeperiode.fra);
+            uke = hentNummerOgDatoForForsteUke(props.aktivtMeldekort.meldeperiode.fra);
         } else if (ukeNr === 2) {
-            uke = hentNummerOgDatoForAndreUke(props.aktivtMeldekort.meldekort.meldeperiode.til);
+            uke = hentNummerOgDatoForAndreUke(props.aktivtMeldekort.meldeperiode.til);
         }
 
         if (dagListe.length > 0) {
@@ -180,8 +180,8 @@ const Meldekortdetaljer: React.FunctionComponent<Props> = (props) => {
             {sporsmalId: 'sporsmal.registrert', svar: props.meldekortdetaljer.sporsmal.arbeidssoker,
                 forklaring: 'forklaring.sporsmal.registrert'  + aap,
                 formatertDato: hentNestePeriodeMedUkerOgDato(
-                    props.aktivtMeldekort.meldekort.meldeperiode.fra,
-                    props.aktivtMeldekort.meldekort.meldeperiode.til)
+                    props.aktivtMeldekort.meldeperiode.fra,
+                    props.aktivtMeldekort.meldeperiode.til)
             }
         ];
     };

--- a/src/app/components/mobilMeny/mobilMeny.tsx
+++ b/src/app/components/mobilMeny/mobilMeny.tsx
@@ -41,6 +41,7 @@ const MobilMeny: React.FunctionComponent<MobilMenyProps&MapStateToProps&MapDispa
                             <li
                                 className={'navlist-item'}
                                 onClick={() => onChange(menypunkt)}
+                                key={menypunkt.tittel}
                             >
                                 <div
                                     className={classNames('item-wrapper', {

--- a/src/app/components/mobilTabell/mobilTabell.less
+++ b/src/app/components/mobilTabell/mobilTabell.less
@@ -1,0 +1,35 @@
+.mobilTabell-container {
+  border-bottom: 1px solid #B7B1A9;
+
+  table.mobilTabell {
+    border-spacing: 0;
+    table-layout: fixed;
+    border-collapse: collapse;
+    width: 100%;
+    tbody {
+
+      tr.tabellRad {
+        height: 2.5rem;
+
+        &:first-child {
+          border-top: 1px solid #B7B1A9;
+        }
+
+        &:nth-child(odd) {
+          background: #f8f8f8;
+
+        }
+        &:nth-child(even) {
+          background: white;
+
+        }
+        th.headerCol {
+
+        }
+        td.dataCol {
+
+        }
+      }
+    }
+  }
+}

--- a/src/app/components/mobilTabell/mobilTabell.less
+++ b/src/app/components/mobilTabell/mobilTabell.less
@@ -23,12 +23,6 @@
           background: white;
 
         }
-        th.headerCol {
-
-        }
-        td.dataCol {
-
-        }
       }
     }
   }

--- a/src/app/components/mobilTabell/mobilTabell.tsx
+++ b/src/app/components/mobilTabell/mobilTabell.tsx
@@ -1,21 +1,22 @@
 import * as React from 'react';
-import { HistoriskeMeldekortRad } from '../../sider/tidligereMeldekort/tidligereMeldekort';
 import { finnRiktigEtikettType } from '../../utils/statusEtikettUtil';
 import EtikettBase from 'nav-frontend-etiketter';
 import Komponentlenke from '../../components/komponentlenke/komponentlenke';
+import { DetaljRad, HistoriskeMeldekortRad } from '../../types/meldekort';
 
 interface MobilTabellProps {
-    rows: HistoriskeMeldekortRad[];
+    rows?: HistoriskeMeldekortRad[] ;
+    row?: DetaljRad;
     columns: {
         key: string,
         label: JSX.Element,
-        cell: any}[];
+        cell?: any}[];
     className?: string;
 }
 
 const MobilTabell: React.FunctionComponent<MobilTabellProps> = (props) => {
 
-    const returnerTabellRad = (header: {key: string, label: JSX.Element, cell: any}, rowData: HistoriskeMeldekortRad) => {
+    const returnerTabellRader = (header: {key: string, label: JSX.Element, cell?: any}, rowData: HistoriskeMeldekortRad) => {
         let tableData: any = '';
         for (let i in rowData) {
             if (i === header.key && header.key === 'status') {
@@ -23,7 +24,7 @@ const MobilTabell: React.FunctionComponent<MobilTabellProps> = (props) => {
                     <EtikettBase type={finnRiktigEtikettType(rowData[i])}>
                         {rowData[i]}
                     </EtikettBase>);
-            } else if (i === header.key && header.key === 'periode') {
+            } else if (i === header.key && header.key === 'periode' && rowData.periode) {
                 tableData = (
                     <Komponentlenke
                         lenketekst={rowData.periode}
@@ -31,30 +32,79 @@ const MobilTabell: React.FunctionComponent<MobilTabellProps> = (props) => {
                         meldekort={rowData.meldekort}
                     />
                 );
-                console.log();
             } else if (i === header.key ) {
                 tableData = rowData[i];
             }
         }
         return (
             <tr key={header.key} className={'tabellRad'}>
-                <th className={'headerCsol'}> {header.label} </th>
-                <td className={'dataCol'}> {tableData} </td>
+                <th> {header.label} </th>
+                <td> {tableData} </td>
             </tr>
         );
     };
 
+    const returnerDetaljRad = (header: {key: string, label: JSX.Element, cell?: any}, rowData: DetaljRad) => {
+        let tableData: any = '';
+
+        for (let i in rowData) {
+            if (i === header.key && header.key === 'kortStatus') {
+                tableData = (
+                    <EtikettBase type={finnRiktigEtikettType(rowData[i])}>
+                        {rowData[i]}
+                    </EtikettBase>);
+            } else if (i === header.key ) {
+                tableData = rowData[i];
+            }
+        }
+        return (
+            <tr key={header.key} className={'tabellRad'}>
+                <th> {header.label} </th>
+                <td> {tableData} </td>
+            </tr>
+        );
+    };
+    const visEnTabell = () => {
+        let resultat = {};
+        if ( typeof props.row !== undefined && props.row) {
+            const test2: DetaljRad = props.row;
+            resultat = props.columns.map((colHeader) => (
+                returnerDetaljRad(colHeader, test2)));
+        }
+        return resultat;
+    };
+
+    const visFlereTabeller = () => {
+        let tabeller;
+        if (props.rows && typeof props.rows !== undefined) {
+            tabeller = props.rows.map(( allRowData: any) => (
+                    <table key={allRowData.meldekort.meldekortId} className={'mobilTabell'}>
+                        <tbody>
+                        {props.columns.map((colHeader) => (
+                            returnerTabellRader(colHeader, allRowData)
+                        ))}
+                        </tbody>
+                    </table>
+                )
+            );
+        }
+        return tabeller;
+    };
+
     return (
         <div className={'mobilTabell-container'}>
-            {props.rows.map( allRowData => (
-                <table key={allRowData.meldekort.meldekortId} className={'mobilTabell'}>
+            { typeof props.row !== undefined && props.row ?
+                (
+                <table key={props.row.meldekortid} className={'mobilTabell'}>
                     <tbody>
-                    {props.columns.map((colHeader) => (
-                        returnerTabellRad(colHeader, allRowData)
-                    ))}
+                        {visEnTabell()}
                     </tbody>
                 </table>
-            ))
+            ) : (
+                <>
+                    {visFlereTabeller()}
+                </>
+                )
             }
         </div>
     );

--- a/src/app/components/mobilTabell/mobilTabell.tsx
+++ b/src/app/components/mobilTabell/mobilTabell.tsx
@@ -11,9 +11,19 @@ interface MobilTabellProps {
 const MobilTabell: React.FunctionComponent<MobilTabellProps> = (props) => {
 
     return (
-        <>
-
-        </>
+        <div className={'mobilTabell_alle'}>
+            {props.rows.map( rowCol => (
+                <table>
+                    {props.columns.map((tableRow, index) => (
+                        <tr>
+                            <th> {rowCol} </th>
+                            <td> {tableRow} </td>
+                        </tr>
+                    ))}
+                </table>
+            ))
+            }
+        </div>
     );
 };
 

--- a/src/app/components/mobilTabell/mobilTabell.tsx
+++ b/src/app/components/mobilTabell/mobilTabell.tsx
@@ -1,25 +1,58 @@
 import * as React from 'react';
+import { HistoriskeMeldekortRad } from '../../sider/tidligereMeldekort/tidligereMeldekort';
+import { finnRiktigEtikettType } from '../../utils/statusEtikettUtil';
+import EtikettBase from 'nav-frontend-etiketter';
+import Komponentlenke from '../../components/komponentlenke/komponentlenke';
 
-// En liste for første kolonne (data navn)
-// En liste for andre kolonne (selve dataen)
 interface MobilTabellProps {
-    rows: {}[];
-    columns: {}[];
+    rows: HistoriskeMeldekortRad[];
+    columns: {
+        key: string,
+        label: JSX.Element,
+        cell: any}[];
     className?: string;
 }
 
 const MobilTabell: React.FunctionComponent<MobilTabellProps> = (props) => {
 
+    const returnerTabellRad = (header: {key: string, label: JSX.Element, cell: any}, rowData: HistoriskeMeldekortRad) => {
+        let tableData: any = '';
+        for (let i in rowData) {
+            if (i === header.key && header.key === 'status') {
+                tableData = (
+                    <EtikettBase type={finnRiktigEtikettType(rowData[i])}>
+                        {rowData[i]}
+                    </EtikettBase>);
+            } else if (i === header.key && header.key === 'periode') {
+                tableData = (
+                    <Komponentlenke
+                        lenketekst={rowData.periode}
+                        rute="/tidligere-meldekort/detaljer"
+                        meldekort={rowData.meldekort}
+                    />
+                );
+                console.log();
+            } else if (i === header.key ) {
+                tableData = rowData[i];
+            }
+        }
+        return (
+            <tr key={header.key} className={'tabellRad'}>
+                <th className={'headerCsol'}> {header.label} </th>
+                <td className={'dataCol'}> {tableData} </td>
+            </tr>
+        );
+    };
+
     return (
-        <div className={'mobilTabell_alle'}>
-            {props.rows.map( rowCol => (
-                <table>
-                    {props.columns.map((tableRow, index) => (
-                        <tr>
-                            <th> {rowCol} </th>
-                            <td> {tableRow} </td>
-                        </tr>
+        <div className={'mobilTabell-container'}>
+            {props.rows.map( allRowData => (
+                <table key={allRowData.meldekort.meldekortId} className={'mobilTabell'}>
+                    <tbody>
+                    {props.columns.map((colHeader) => (
+                        returnerTabellRad(colHeader, allRowData)
                     ))}
+                    </tbody>
                 </table>
             ))
             }

--- a/src/app/components/periodeBanner/periodeBanner.tsx
+++ b/src/app/components/periodeBanner/periodeBanner.tsx
@@ -4,12 +4,12 @@ import Innholdstittel from 'nav-frontend-typografi/lib/innholdstittel';
 import { FormattedMessage } from 'react-intl';
 import Normaltekst from 'nav-frontend-typografi/lib/normaltekst';
 import { hentDatoPeriode, hentUkePeriode } from '../../utils/dates';
-import { AktivtMeldekortState } from '../../reducers/aktivtMeldekortReducer';
 import { RootState } from '../../store/configureStore';
 import { connect } from 'react-redux';
+import { Meldekort } from '../../types/meldekort';
 
 interface MapStateToProps {
-    aktivtMeldekort: AktivtMeldekortState;
+    aktivtMeldekort: Meldekort;
 }
 
 interface PeriodeBannerProps {
@@ -20,9 +20,8 @@ type Props = PeriodeBannerProps & MapStateToProps;
 
 const PeriodeBanner: React.FunctionComponent<Props> = (props) => {
 
-    const meldeperiode = props.aktivtMeldekort.meldekort.meldeperiode;
+    const { meldeperiode } = props.aktivtMeldekort;
     const { className = '' } = props;
-
     return (
         <section className={'seksjon periodeBanner ' + className}>
             <Ingress className="flex-innhold sentrert">

--- a/src/app/components/tabell/tabell.less
+++ b/src/app/components/tabell/tabell.less
@@ -21,9 +21,6 @@
       tr, td {
         border-bottom: 1px solid #B7B1A9;
 
-        .blaEtikett {
-          background-color: #A3DFF3;
-        }
       }
     }
     .jsonOdd {
@@ -32,80 +29,3 @@
   }
 }
 
-@media (max-width: @screen-sm) {
-  .tabell, .tabell.mobilversjon {
-
-    td, th {
-      padding: 0.5rem;
-    }
-  }
-
-  .tabell.mobilversjon {
-    // background-color: #e79999;
-
-    .jsonTable {
-
-      th {
-        font-weight: normal;
-      }
-
-      table, thead, tbody, th, td, tr {
-        display: block;
-      }
-
-      thead tr {
-        position: absolute;
-        top: -9999px;
-        left: -9999px;
-      }
-
-      .jsonRow {
-
-        tr, td {
-          border-bottom: 1px solid #B7B1A9;
-        }
-      }
-
-
-      tr {
-        padding: 1rem 0 1rem 0;
-        border-bottom: 1px solid @navMorkGra;
-      }
-
-      tr:nth-child(odd) {
-        background: #f8f8f8;
-      }
-
-      td {
-        /* Behave  like a "row" */
-        border: none;
-        border-bottom: 1px solid #eee;
-        position: relative;
-        padding-left: 50%;
-        min-height: 2.5rem;
-      }
-
-      td:before {
-        /* Now like a table header */
-        position: absolute;
-        left: 1rem;
-        width: 45%;
-        padding-right: 10px;
-        white-space: nowrap;
-      }
-
-      /*
-		Label the data
-    You could also use a data-* attribute and content for this. That way "bloats" the HTML,
-    this way means you need to keep HTML and CSS in sync.
-    Lea Verou has a clever way to handle with text-shadow.
-		*/
-      td:nth-of-type(1):before { content: "Periode"; }
-      td:nth-of-type(2):before { content: "Dato"; }
-      td:nth-of-type(3):before { content: "Mottatt"; }
-      td:nth-of-type(4):before { content: "Status"; }
-      td:nth-of-type(5):before { content: "Brutto Beløp"; }
-
-    }
-  }
-}

--- a/src/app/components/tabell/tabell.tsx
+++ b/src/app/components/tabell/tabell.tsx
@@ -1,41 +1,20 @@
 import * as React from 'react';
-import MobilTabell from '../mobilTabell/mobilTabell';
 
 interface TabellProps {
     rows: {}[];
     columns: {}[];
     className?: string;
-    mobilSkjerm?: boolean;
 }
 
 const Tabell: React.FunctionComponent<TabellProps> = (props) => {
     const JsonTable = require('ts-react-json-table');
-    const tabellClass = props.mobilSkjerm ? 'tabell mobilversjon' : 'tabell';
 
-       /* {!props.mobilSkjerm ? (
-            <MobilTabell
-                rows={props.rows}
-                columns={props.columns}
-            />
-        ) : (
-            <div className={tabellClass}>
-                <JsonTable
-                    rows={props.rows}
-                    columns={props.columns}
-                    className={props.className}
-                />
-            </div>
-        )}*/
     return (
-        <>
-            <div className={tabellClass}>
-                <JsonTable
-                    rows={props.rows}
-                    columns={props.columns}
-                    className={props.className}
-                />
-            </div>
-        </>
+        <JsonTable
+            rows={props.rows}
+            columns={props.columns}
+            className={props.className}
+        />
     );
 };
 

--- a/src/app/components/tabell/tabell.tsx
+++ b/src/app/components/tabell/tabell.tsx
@@ -10,11 +10,13 @@ const Tabell: React.FunctionComponent<TabellProps> = (props) => {
     const JsonTable = require('ts-react-json-table');
 
     return (
-        <JsonTable
-            rows={props.rows}
-            columns={props.columns}
-            className={props.className}
-        />
+        <div className={'tabell'}>
+            <JsonTable
+                rows={props.rows}
+                columns={props.columns}
+                className={props.className}
+            />
+        </div>
     );
 };
 

--- a/src/app/epics/innsendingEpics.tsx
+++ b/src/app/epics/innsendingEpics.tsx
@@ -13,7 +13,7 @@ const hentKorrigertId: AppEpic = (action$, state$) =>
         filter(isActionOf([InnsendingActions.hentKorrigertId.request])),
         withLatestFrom(state$),
         switchMap(([action, state]) =>
-            from(fetchKorrigertId(state.aktivtMeldekort.meldekort.meldekortId)).pipe(
+            from(fetchKorrigertId(state.aktivtMeldekort.meldekortId)).pipe(
                 map(InnsendingActions.hentKorrigertId.success),
                 catchError(error =>
                     of(InnsendingActions.hentKorrigertId.failure(error), MeldekortActions.apiKallFeilet(error))

--- a/src/app/epics/meldekortdetaljerEpics.tsx
+++ b/src/app/epics/meldekortdetaljerEpics.tsx
@@ -12,7 +12,7 @@ const hentMeldekortdetaljer: AppEpic = (action$, state$) =>
         filter(isActionOf([MeldekortdetaljerActions.hentMeldekortdetaljer.request])),
         withLatestFrom(state$),
         switchMap(([action, state]) =>
-            from(fetchMeldekortdetaljer(state.aktivtMeldekort.meldekort.meldekortId)).pipe(
+            from(fetchMeldekortdetaljer(state.aktivtMeldekort.meldekortId)).pipe(
                 map(MeldekortdetaljerActions.hentMeldekortdetaljer.success),
                 catchError(error =>
                     of(MeldekortdetaljerActions.hentMeldekortdetaljer.failure(error), MeldekortActions.apiKallFeilet(error))

--- a/src/app/mock/responses/person.json
+++ b/src/app/mock/responses/person.json
@@ -13,6 +13,7 @@
         "fra": "2018-12-31T12:00:00+01:00",
         "til": "2019-01-13T12:00:00+01:00",
         "kortKanSendesFra": "2019-01-12T12:00:00+01:00",
+        "kanKortSendes": false,
         "periodeKode": "201901"
       },
       "meldegruppe": "DAGP",
@@ -29,6 +30,7 @@
         "fra": "2019-01-14T12:00:00+01:00",
         "til": "2019-01-27T12:00:00+01:00",
         "kortKanSendesFra": "2019-01-26T12:00:00+01:00",
+        "kanKortSendes": true,
         "periodeKode": "201903"
       },
       "meldegruppe": "ATTF",
@@ -43,6 +45,7 @@
         "fra": "2019-01-28T12:00:00+01:00",
         "til": "2019-02-10T12:00:00+01:00",
         "kortKanSendesFra": "2019-02-09T12:00:00+01:00",
+        "kanKortSendes": true,
         "periodeKode": "201905"
       },
       "meldegruppe": "DAGP",
@@ -57,22 +60,39 @@
         "fra": "2019-02-11T12:00:00+01:00",
         "til": "2019-02-24T12:00:00+01:00",
         "kortKanSendesFra": "2019-02-23T12:00:00+01:00",
+        "kanKortSendes": true,
         "periodeKode": "201907"
       },
       "meldegruppe": "DAGP",
       "kortStatus": "OPPRE",
       "erForskuddsPeriode": false,
       "korrigerbart": true
+    },
+    {
+      "meldekortId": 1011121318,
+      "kortType": "ELEKTRONISK",
+      "meldeperiode": {
+        "fra": "2019-02-11T12:00:00+01:00",
+        "til": "2019-02-24T12:00:00+01:00",
+        "kortKanSendesFra": "2019-02-23T12:00:00+01:00",
+        "kanKortSendes": false,
+        "periodeKode": "201907"
+      },
+      "meldegruppe": "DAGP",
+      "kortStatus": "OPPRE",
+      "erForskuddsPeriode": false,
+      "korrigerbart": false
     }
   ],
   "etterregistrerteMeldekort": [
     {
-      "meldekortId": 1011121315,
+      "meldekortId": 1011121325,
       "kortType": "ELEKTRONISK",
       "meldeperiode": {
         "fra": "2019-01-14T12:00:00+01:00",
         "til": "2019-01-27T12:00:00+01:00",
         "kortKanSendesFra": "2019-01-26T12:00:00+01:00",
+        "kanKortSendes": true,
         "periodeKode": "201903"
       },
       "meldegruppe": "ATTF",
@@ -81,12 +101,13 @@
       "korrigerbart": true
     },
     {
-      "meldekortId": 1011121316,
+      "meldekortId": 1011121326,
       "kortType": "ELEKTRONISK",
       "meldeperiode": {
         "fra": "2019-01-28T12:00:00+01:00",
         "til": "2019-02-10T12:00:00+01:00",
         "kortKanSendesFra": "2019-02-09T12:00:00+01:00",
+        "kanKortSendes": true,
         "periodeKode": "201905"
       },
       "meldegruppe": "DAGP",
@@ -95,12 +116,13 @@
       "korrigerbart": true
     },
     {
-      "meldekortId": 1011121317,
+      "meldekortId": 1011121327,
       "kortType": "ELEKTRONISK",
       "meldeperiode": {
         "fra": "2019-02-11T12:00:00+01:00",
         "til": "2019-02-24T12:00:00+01:00",
         "kortKanSendesFra": "2019-02-23T12:00:00+01:00",
+        "kanKortSendes": true,
         "periodeKode": "201907"
       },
       "meldegruppe": "DAGP",

--- a/src/app/reducers/aktivtMeldekortReducer.tsx
+++ b/src/app/reducers/aktivtMeldekortReducer.tsx
@@ -2,18 +2,14 @@ import { KortStatus, KortType, Meldegruppe, Meldekort } from '../types/meldekort
 import { AktivtMeldekortActions, AktivtMeldekortActionsTypes } from '../actions/aktivtMeldekort';
 import { getType } from 'typesafe-actions';
 
-export interface AktivtMeldekortState {
-    meldekort: Meldekort;
-}
-
-const initialState: AktivtMeldekortState = {
-    meldekort: {
+const initialState: Meldekort = {
         meldekortId: 0,
         kortType: KortType.RETUR,
         meldeperiode: {
             til: new Date(),
             fra: new Date(),
             kortKanSendesFra: new Date(),
+            kanKortSendes: false,
             periodeKode: ''
         },
         meldegruppe: Meldegruppe.ATTF,
@@ -21,12 +17,10 @@ const initialState: AktivtMeldekortState = {
         bruttoBelop: 0,
         mottattDato: new Date(),
         korrigerbart: false
-
-    }
 };
 
-const aktivtMeldekortReducer = (state: AktivtMeldekortState = initialState,
-                                action: AktivtMeldekortActionsTypes): AktivtMeldekortState => {
+const aktivtMeldekortReducer = (state: Meldekort = initialState,
+                                action: AktivtMeldekortActionsTypes): Meldekort => {
     switch (action.type) {
         case getType(AktivtMeldekortActions.oppdaterAktivtMeldekort):
             return { ...state, ...action.payload };

--- a/src/app/reducers/meldekortReducer.tsx
+++ b/src/app/reducers/meldekortReducer.tsx
@@ -1,0 +1,19 @@
+import { SendteMeldekortState } from '../types/meldekort';
+import { MeldekortActionTypes, MeldekortActions } from '../actions/meldekort';
+import { getType } from 'typesafe-actions';
+
+const initialState: SendteMeldekortState = {
+    sendteMeldekort: []
+};
+
+const meldekortReducer = (state: SendteMeldekortState = initialState,
+                          action: MeldekortActionTypes): SendteMeldekortState => {
+    switch (action.type) {
+        case getType(MeldekortActions.leggTilInnsendtMeldekort):
+            return { ...state, sendteMeldekort: action.payload};
+        default:
+            return state;
+    }
+};
+
+export default meldekortReducer;

--- a/src/app/sider/etterregistrerMeldekort/etterregistrerMeldekort.tsx
+++ b/src/app/sider/etterregistrerMeldekort/etterregistrerMeldekort.tsx
@@ -17,6 +17,7 @@ import { Innsendingstyper } from '../../types/innsending';
 import { Person } from '../../types/person';
 import { Redirect } from 'react-router';
 import { AktivtMeldekortActions } from '../../actions/aktivtMeldekort';
+import { hentIntl } from '../../utils/intlUtil';
 
 interface MapStateToProps {
     person: Person;
@@ -89,7 +90,9 @@ class EtterregistrerMeldekort extends React.Component<Props, any> {
         return !ettMeldekort ? (
             <main className="sideinnhold">
                 <section className="seksjon flex-innhold tittel-sprakvelger">
-                    <Innholdstittel className="seksjon"> {rows.length} meldekort klar for etteregistrering </Innholdstittel>
+                    <Innholdstittel className="seksjon">
+                        {hentIntl().formatMessage({id: 'overskrift.etterregistrering.innsending'})}
+                    </Innholdstittel>
                     <Sprakvelger/>
                 </section>
                 <section className="seksjon">

--- a/src/app/sider/etterregistrerMeldekort/etterregistrerMeldekort.tsx
+++ b/src/app/sider/etterregistrerMeldekort/etterregistrerMeldekort.tsx
@@ -12,7 +12,7 @@ import { Router } from '../../types/router';
 import Tabell from '../../components/tabell/tabell';
 import NavKnapp, { knappTyper } from '../../components/knapp/navKnapp';
 import { KortStatus, Meldekort } from '../../types/meldekort';
-import { hentDatoPeriode, hentUkePeriode, kanMeldekortSendesInn } from '../../utils/dates';
+import { hentDatoPeriode, hentUkePeriode } from '../../utils/dates';
 import { Innsendingstyper } from '../../types/innsending';
 import { Person } from '../../types/person';
 import { Redirect } from 'react-router';
@@ -55,7 +55,7 @@ class EtterregistrerMeldekort extends React.Component<Props, any> {
         }
         return this.props.person.etterregistrerteMeldekort.filter((meldekortObj) =>
             (meldekortObj.kortStatus === KortStatus.OPPRE || meldekortObj.kortStatus === KortStatus.SENDT) &&
-            (kanMeldekortSendesInn(meldekortObj.meldeperiode.kortKanSendesFra)));
+            (meldekortObj.meldeperiode.kanKortSendes));
     }
 
     hentMeldekortRaderFraPerson = () => {

--- a/src/app/sider/innsending/bekreftelsesside/bekreftelse.tsx
+++ b/src/app/sider/innsending/bekreftelsesside/bekreftelse.tsx
@@ -3,7 +3,6 @@ import AlertStripe from 'nav-frontend-alertstriper';
 import Meldekortdetaljer from '../../../components/meldekortdetaljer/meldekortdetaljer';
 import NavKnapp, { knappTyper } from '../../../components/knapp/navKnapp';
 import Sprakvelger from '../../../components/sprakvelger/sprakvelger';
-import { AktivtMeldekortState } from '../../../reducers/aktivtMeldekortReducer';
 import { connect } from 'react-redux';
 import { FormattedHTMLMessage, FormattedMessage } from 'react-intl';
 import { Innholdstittel, Normaltekst } from 'nav-frontend-typografi';
@@ -31,7 +30,7 @@ import { Redirect } from 'react-router';
 
 interface MapStateToProps {
     innsending: InnsendingState;
-    aktivtMeldekort: AktivtMeldekortState;
+    aktivtMeldekort: Meldekort;
     person: Person;
 }
 
@@ -67,10 +66,10 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
                 id: '',
                 personId: person.personId,
                 fodselsnr: person.fodselsnr,
-                meldekortId: this.erInnsendingKorrigering() ? innsending.korrigertMeldekortId : aktivtMeldekort.meldekort.meldekortId,
-                meldeperiode: aktivtMeldekort.meldekort.meldeperiode.periodeKode,
+                meldekortId: this.erInnsendingKorrigering() ? innsending.korrigertMeldekortId : aktivtMeldekort.meldekortId,
+                meldeperiode: aktivtMeldekort.meldeperiode.periodeKode,
                 arkivnokkel: '1-ELEKTRONISK',
-                kortType: this.erInnsendingKorrigering() ? KortType.KORRIGERT_ELEKTRONISK : aktivtMeldekort.meldekort.kortType,
+                kortType: this.erInnsendingKorrigering() ? KortType.KORRIGERT_ELEKTRONISK : aktivtMeldekort.kortType,
                 meldeDato: new Date(),
                 lestDato: new Date(),
                 begrunnelse: this.erInnsendingKorrigering() ? innsending.begrunnelse.valgtArsak : '',
@@ -95,14 +94,14 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
 
     konverterMeldekortdetaljerTilMeldekortdetaljerInnsending = (): MeldekortdetaljerInnsending => {
         let { meldekortdetaljer } = this.state.meldekortdetaljer;
-        let { meldekort } = this.props.aktivtMeldekort;
+        let { aktivtMeldekort } = this.props;
         return {
             meldekortId: meldekortdetaljer.meldekortId,
             kortType: meldekortdetaljer.kortType,
-            kortStatus: meldekort.kortStatus,
-            meldegruppe: meldekort.meldegruppe,
+            kortStatus: aktivtMeldekort.kortStatus,
+            meldegruppe: aktivtMeldekort.meldegruppe,
             mottattDato: meldekortdetaljer.meldeDato,
-            meldeperiode: meldekort.meldeperiode,
+            meldeperiode: aktivtMeldekort.meldeperiode,
             erArbeidssokerNestePeriode: meldekortdetaljer.sporsmal.arbeidssoker,
             korrigerbart: this.props.innsending.innsendingstype !== Innsendingstyper.korrigering,
             begrunnelse: meldekortdetaljer.begrunnelse,
@@ -110,7 +109,7 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
             fnr: meldekortdetaljer.fodselsnr,
             personId: meldekortdetaljer.personId,
             sesjonsId: 'test', // TODO: Denne må settes til noe fornuftig. Mulig vi må lage en egen sesjonsId.
-            fravaersdager: this.hentFravaersdager(meldekortdetaljer, meldekort)
+            fravaersdager: this.hentFravaersdager(meldekortdetaljer, aktivtMeldekort)
         };
     }
 
@@ -194,7 +193,7 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
     }
 
     render() {
-        let { meldegruppe } = this.props.aktivtMeldekort.meldekort;
+        let { meldegruppe } = this.props.aktivtMeldekort;
         let { valideringsResultat } = this.props.innsending;
         let { meldekortdetaljer } = this.state.meldekortdetaljer;
         let { feilmelding } = this.state;
@@ -268,10 +267,9 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
 }
 
 const mapStateToProps = (state: RootState): MapStateToProps => {
-    const meldekort: AktivtMeldekortState = {meldekort: state.aktivtMeldekort.meldekort};
     return {
         innsending: state.innsending,
-        aktivtMeldekort: meldekort,
+        aktivtMeldekort: state.aktivtMeldekort,
         person: state.person,
     };
 };

--- a/src/app/sider/innsending/innsendingRoutes.tsx
+++ b/src/app/sider/innsending/innsendingRoutes.tsx
@@ -137,7 +137,7 @@ class InnsendingRoutes extends React.Component<InnsendingRoutesProps> {
 const mapStateToProps = (state: RootState): MapStateToProps => {
     return {
         innsending: state.innsending,
-        aktivtMeldekort: state.aktivtMeldekort.meldekort,
+        aktivtMeldekort: state.aktivtMeldekort,
         meldekortdetaljer: state.meldekortdetaljer.meldekortdetaljer,
         router: state.router
     };

--- a/src/app/sider/innsending/kvitteringsside/kvittering.less
+++ b/src/app/sider/innsending/kvitteringsside/kvittering.less
@@ -1,3 +1,13 @@
 .alertSendt {
   margin-bottom: 2rem;
 }
+
+.etterregistrering_info {
+  text-align: center;
+}
+
+.kvitteringsKnapper {
+  button {
+    margin-top: 1rem;
+  }
+}

--- a/src/app/sider/innsending/sporsmalsside/sporsmal/sporsmalsGruppe.tsx
+++ b/src/app/sider/innsending/sporsmalsside/sporsmal/sporsmalsGruppe.tsx
@@ -1,18 +1,18 @@
 import * as React from 'react';
 
 import Sporsmal from './sporsmal';
-import {connect} from 'react-redux';
-import {Dispatch} from 'redux';
-import {hentIntl} from '../../../../utils/intlUtil';
-import {InnsendingState, Innsendingstyper} from '../../../../types/innsending';
-import {InnsendingActions} from '../../../../actions/innsending';
-import {RootState} from '../../../../store/configureStore';
-import {Sporsmal as Spm} from './sporsmalConfig';
-import {AktivtMeldekortState} from '../../../../reducers/aktivtMeldekortReducer';
-import {hentNestePeriodeMedUkerOgDato} from '../../../../utils/dates';
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
+import { hentIntl } from '../../../../utils/intlUtil';
+import { InnsendingState, Innsendingstyper } from '../../../../types/innsending';
+import { InnsendingActions } from '../../../../actions/innsending';
+import { RootState } from '../../../../store/configureStore';
+import { Sporsmal as Spm } from './sporsmalConfig';
+import { hentNestePeriodeMedUkerOgDato } from '../../../../utils/dates';
+import { Meldekort } from '../../../../types/meldekort';
 
 interface MapStateToProps {
-    aktivtMeldekort: AktivtMeldekortState;
+    aktivtMeldekort: Meldekort;
 }
 
 interface MapDispatchToProps {
@@ -64,7 +64,7 @@ class SporsmalsGruppe extends React.Component<SporsmalsGruppeProps> {
                 skalVareDisabled = true;
             }
         }
-        let { til, fra } = this.props.aktivtMeldekort.meldekort.meldeperiode;
+        let { til, fra } = this.props.aktivtMeldekort.meldeperiode;
         return(
             <Sporsmal
                 sporsmalsobjekt={sporsmalsobj}

--- a/src/app/sider/innsending/sporsmalsside/sporsmalsside.tsx
+++ b/src/app/sider/innsending/sporsmalsside/sporsmalsside.tsx
@@ -8,7 +8,6 @@ import veileder from '../../../ikoner/veileder.svg';
 import Veilederpanel from 'nav-frontend-veilederpanel';
 import { UtfyltDag } from '../utfyllingsside/utfylling/utfyllingConfig';
 import { Begrunnelse, InnsendingState, Innsendingstyper, SpmSvar } from '../../../types/innsending';
-import { AktivtMeldekortState } from '../../../reducers/aktivtMeldekortReducer';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { FormattedHTMLMessage, FormattedMessage } from 'react-intl';
@@ -18,14 +17,14 @@ import { ikkeFortsetteRegistrertContent } from '../../../components/modal/ikkeFo
 import { IModal, ModalKnapp } from '../../../types/ui';
 import { Innholdstittel } from 'nav-frontend-typografi';
 import { InnsendingActions } from '../../../actions/innsending';
-import { Meldegruppe } from '../../../types/meldekort';
+import { Meldegruppe, Meldekort } from '../../../types/meldekort';
 import { RouteComponentProps } from 'react-router';
 import { scrollTilElement } from '../../../utils/scroll';
 import { Sporsmal } from './sporsmal/sporsmalConfig';
 import { UiActions } from '../../../actions/ui';
 
 interface MapStateToProps {
-    aktivtMeldekort: AktivtMeldekortState;
+    aktivtMeldekort: Meldekort;
     innsending: InnsendingState;
 }
 
@@ -217,7 +216,7 @@ class Sporsmalsside extends React.Component<SporsmalssideProps, any> {
 
     resetSporsmalOgUtfyllingHvisAktivtMeldekortIdIkkeErLikInnsendingMeldekortId = () => {
         const { aktivtMeldekort, innsending, resetSporsmalOgUtfylling } = this.props;
-        if ( aktivtMeldekort.meldekort.meldekortId !== innsending.meldekortId ) {
+        if ( aktivtMeldekort.meldekortId !== innsending.meldekortId ) {
             resetSporsmalOgUtfylling();
         }
     }
@@ -241,7 +240,7 @@ class Sporsmalsside extends React.Component<SporsmalssideProps, any> {
 
     render() {
         const { innsending, aktivtMeldekort } = this.props;
-        const meldegruppeErAAP = aktivtMeldekort.meldekort.meldegruppe === Meldegruppe.ATTF;
+        const meldegruppeErAAP = aktivtMeldekort.meldegruppe === Meldegruppe.ATTF;
         const brukermelding = hentIntl().formatMessage({id: 'meldekort.bruker.melding'});
         return (
             <main>
@@ -324,9 +323,8 @@ class Sporsmalsside extends React.Component<SporsmalssideProps, any> {
 
 // TODO: Bytt til å hente meldekortDetaljer fra Store
 const mapStateToProps = (state: RootState): MapStateToProps => {
-    const meldekort: AktivtMeldekortState = {meldekort: state.aktivtMeldekort.meldekort};
     return {
-        aktivtMeldekort: meldekort,
+        aktivtMeldekort: state.aktivtMeldekort,
         innsending: state.innsending
     };
 };

--- a/src/app/sider/innsending/utfyllingsside/utfyllingsside.tsx
+++ b/src/app/sider/innsending/utfyllingsside/utfyllingsside.tsx
@@ -7,12 +7,11 @@ import { hentDatoForForsteUke, hentUkenummerForDato } from '../../../utils/dates
 import { InnsendingState, SpmSvar, UtfyllingFeil } from '../../../types/innsending';
 import { RootState } from '../../../store/configureStore';
 import { connect } from 'react-redux';
-import { AktivtMeldekortState } from '../../../reducers/aktivtMeldekortReducer';
 import Konstanter from '../../../utils/consts';
 import { UtfyltDag } from './utfylling/utfyllingConfig';
 import { hentIntl } from '../../../utils/intlUtil';
 import AlertStripe from 'nav-frontend-alertstriper';
-import { Meldegruppe } from '../../../types/meldekort';
+import { Meldegruppe, Meldekort } from '../../../types/meldekort';
 import { scrollTilElement } from '../../../utils/scroll';
 import UkePanel from '../../../components/ukepanel/ukepanel';
 import { Dispatch } from 'redux';
@@ -20,7 +19,7 @@ import { InnsendingActions } from '../../../actions/innsending';
 
 interface MapStateToProps {
     innsending: InnsendingState;
-    aktivtMeldekort: AktivtMeldekortState;
+    aktivtMeldekort: Meldekort;
 }
 
 interface MapDispatchToProps {
@@ -171,7 +170,7 @@ class Utfyllingsside extends React.Component<UtfyllingssideProps, UtfyllingFeil>
     }
 
     render() {
-        let { meldeperiode } = this.props.aktivtMeldekort.meldekort;
+        let { meldeperiode } = this.props.aktivtMeldekort;
 
         return(
             <main>
@@ -188,14 +187,14 @@ class Utfyllingsside extends React.Component<UtfyllingssideProps, UtfyllingFeil>
                         faktiskUkeNummer={hentUkenummerForDato(meldeperiode.fra)}
                         datoTittel={hentDatoForForsteUke(meldeperiode.fra)}
                         utfyllingFeil={this.state}
-                        erAap={this.props.aktivtMeldekort.meldekort.meldegruppe === Meldegruppe.ATTF}
+                        erAap={this.props.aktivtMeldekort.meldegruppe === Meldegruppe.ATTF}
                     />
                     <UkePanel
                         ukenummer={Konstanter().andreUke}
                         faktiskUkeNummer={hentUkenummerForDato(meldeperiode.til)}
                         datoTittel={hentDatoForForsteUke(meldeperiode.til)}
                         utfyllingFeil={this.state}
-                        erAap={this.props.aktivtMeldekort.meldekort.meldegruppe === Meldegruppe.ATTF}
+                        erAap={this.props.aktivtMeldekort.meldegruppe === Meldegruppe.ATTF}
                     />
                 </section>
                 <section className="seksjon flex-innhold sentrert">
@@ -226,10 +225,9 @@ class Utfyllingsside extends React.Component<UtfyllingssideProps, UtfyllingFeil>
 }
 
 const mapStateToProps = (state: RootState): MapStateToProps => {
-    const meldekort: AktivtMeldekortState = {meldekort: state.aktivtMeldekort.meldekort};
     return {
         innsending: state.innsending,
-        aktivtMeldekort: meldekort,
+        aktivtMeldekort: state.aktivtMeldekort,
     };
 };
 

--- a/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
+++ b/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
@@ -17,10 +17,11 @@ import { selectRouter } from '../../../selectors/router';
 import utklippstavle from '../../../ikoner/utklippstavle.svg';
 import NavFrontendSpinner from 'nav-frontend-spinner';
 import NavKnapp, { knappTyper } from '../../../components/knapp/navKnapp';
-import { Meldegruppe, Meldekort } from '../../../types/meldekort';
+import { DetaljRad, Meldegruppe, Meldekort } from '../../../types/meldekort';
 import { formaterBelop } from '../../../utils/numberFormat';
 import { Innsendingstyper } from '../../../types/innsending';
 import PrintKnapp from '../../../components/print/printKnapp';
+import MobilTabell from '../../../components/mobilTabell/mobilTabell';
 
 interface MapStateToProps {
     meldekortdetaljer: MeldekortdetaljerState;
@@ -34,15 +35,22 @@ interface MapDispatchToProps {
 
 type Props = MapDispatchToProps&MapStateToProps;
 
-class Detaljer extends React.Component<Props> {
+class Detaljer extends React.Component<Props, {windowSize: number}> {
+    constructor(props: any) {
+        super(props);
+        this.state = {
+            windowSize: window.innerWidth
+        };
+    }
 
-    settTabellrader = (meldekort: Meldekort) => {
-        return [{
+    settTabellrader = (meldekort: Meldekort): DetaljRad => {
+        return {
+            meldekortid: meldekort.meldekortId,
             mottattDato: formaterDato(meldekort.mottattDato),
             kortStatus: mapKortStatusTilTekst(meldekort.kortStatus),
             bruttoBelop: formaterBelop(meldekort.bruttoBelop),
             kortType: mapKortTypeTilTekst(meldekort.kortType)
-        }];
+        };
     }
 
     sjekkAktivtMeldekortOgRedirect = () => {
@@ -56,7 +64,14 @@ class Detaljer extends React.Component<Props> {
     componentDidMount() {
         this.props.hentMeldekortdetaljer();
         this.sjekkAktivtMeldekortOgRedirect();
+        window.addEventListener('resize', this.handleWindowSize);
+
     }
+
+    handleWindowSize = () =>
+        this.setState({
+            windowSize: window.innerWidth
+        })
 
     innhold = () => {
 
@@ -75,7 +90,9 @@ class Detaljer extends React.Component<Props> {
             {key: 'bruttoBelop', label: <FormattedMessage id="overskrift.bruttoBelop"/>},
             {key: 'kortType', label: <FormattedMessage id="overskrift.meldekorttype"/>}
         ];
-        let { meldegruppe } = aktivtMeldekort;
+        const { meldegruppe } = aktivtMeldekort;
+
+        const erDesktopEllerTablet = this.state.windowSize > 768;
 
         return (
             <>
@@ -83,7 +100,17 @@ class Detaljer extends React.Component<Props> {
                 <PeriodeBanner/>
                 <section className="seksjon">
                     <div className="tabell-detaljer">
-                        <Tabell rows={rows} columns={columns}/>
+                        {erDesktopEllerTablet ? (
+                            <Tabell
+                                rows={[rows]}
+                                columns={columns}
+                            />
+                        ) : (
+                            <MobilTabell
+                                row={rows}
+                                columns={columns}
+                            />
+                        )}
                     </div>
                 </section>
                 {meldekortdetaljer.meldekortdetaljer.id !== '' ?

--- a/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
+++ b/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
@@ -3,7 +3,6 @@ import EtikettBase from 'nav-frontend-etiketter';
 import Meldekortdetaljer from '../../../components/meldekortdetaljer/meldekortdetaljer';
 import PeriodeBanner from '../../../components/periodeBanner/periodeBanner';
 import Tabell from '../../../components/tabell/tabell';
-import { AktivtMeldekortState } from '../../../reducers/aktivtMeldekortReducer';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { finnRiktigEtikettType } from '../../../utils/statusEtikettUtil';
@@ -25,7 +24,7 @@ import PrintKnapp from '../../../components/print/printKnapp';
 
 interface MapStateToProps {
     meldekortdetaljer: MeldekortdetaljerState;
-    aktivtMeldekort: AktivtMeldekortState;
+    aktivtMeldekort: Meldekort;
     router: Router;
 }
 
@@ -47,7 +46,7 @@ class Detaljer extends React.Component<Props> {
     }
 
     sjekkAktivtMeldekortOgRedirect = () => {
-        if (this.props.aktivtMeldekort.meldekort.meldekortId === 0) {
+        if (this.props.aktivtMeldekort.meldekortId === 0) {
             const pathname = this.props.router.location.pathname;
             const tidligereMeldekort = '/tidligere-meldekort';
             pathname !== tidligereMeldekort && history.push(tidligereMeldekort);
@@ -62,7 +61,7 @@ class Detaljer extends React.Component<Props> {
     innhold = () => {
 
         const { meldekortdetaljer, aktivtMeldekort } = this.props;
-        const rows = this.settTabellrader(aktivtMeldekort.meldekort);
+        const rows = this.settTabellrader(aktivtMeldekort);
         const columns = [
             {key: 'mottattDato', label: <FormattedMessage id="overskrift.mottatt"/>},
             {key: 'kortStatus', label: <FormattedMessage id="overskrift.status"/>, cell: function( row: any, columnKey: any) {
@@ -76,7 +75,7 @@ class Detaljer extends React.Component<Props> {
             {key: 'bruttoBelop', label: <FormattedMessage id="overskrift.bruttoBelop"/>},
             {key: 'kortType', label: <FormattedMessage id="overskrift.meldekorttype"/>}
         ];
-        let { meldegruppe } = aktivtMeldekort.meldekort;
+        let { meldegruppe } = aktivtMeldekort;
 
         return (
             <>
@@ -107,13 +106,13 @@ class Detaljer extends React.Component<Props> {
                         tekstid={'naviger.forrige'}
                         className={'navigasjonsknapp'}
                     />
-                    {aktivtMeldekort.meldekort.korrigerbart ?
+                    {aktivtMeldekort.korrigerbart ?
                         <NavKnapp
                             type={knappTyper.standard}
                             nestePath={router.location.pathname + '/korriger'}
                             tekstid={'korriger.meldekort'}
                             className={'navigasjonsknapp'}
-                            nesteAktivtMeldekort={aktivtMeldekort.meldekort}
+                            nesteAktivtMeldekort={aktivtMeldekort}
                             nesteInnsendingstype={Innsendingstyper.korrigering}
                         /> : null
                     }

--- a/src/app/sider/tidligereMeldekort/tidligereMeldekort.tsx
+++ b/src/app/sider/tidligereMeldekort/tidligereMeldekort.tsx
@@ -92,12 +92,39 @@ class TidligereMeldekort extends React.Component<Props> {
             {key: 'bruttobelop', label: <FormattedMessage id="overskrift.bruttoBelop" />, cell: 'bruttobelop'},
         ];
 
-        return (
-            <Tabell
+        const returnerTabellRad = (header: {key: string, label: JSX.Element, cell: any}, rowData: HistoriskeMeldekortRad) => {
+            let tableD = 'data';
+            for (let i in rowData) {
+                if (i === header.key) {
+                    tableD = rowData[i];
+                }
+            }
+
+            return (
+                <tr key={header.key}>
+                    <th> {header.label} </th>
+                    <td> {tableD} </td>
+                </tr>
+            );
+        }
+
+            /*<Tabell
                 rows={rows}
                 columns={columns}
-                mobilSkjerm={true}
-            />
+            />*/
+        return (
+            <div className={'mobilTabell_alle'}>
+                {rows.map( allRowData => (
+                    <table key={allRowData.meldekort.meldekortId}>
+                        <tbody>
+                            {columns.map((colHeader) => (
+                                returnerTabellRad(colHeader, allRowData)
+                            ))}
+                        </tbody>
+                    </table>
+                ))
+                }
+            </div>
         );
     }
 

--- a/src/app/sider/tidligereMeldekort/tidligereMeldekort.tsx
+++ b/src/app/sider/tidligereMeldekort/tidligereMeldekort.tsx
@@ -21,7 +21,7 @@ import { HistoriskeMeldekortState } from '../../reducers/historiskeMeldekortRedu
 import { Innholdstittel } from 'nav-frontend-typografi';
 import { InnsendingActions } from '../../actions/innsending';
 import { mapKortStatusTilTekst } from '../../utils/mapper';
-import { Meldekort } from '../../types/meldekort';
+import { HistoriskeMeldekortRad, Meldekort } from '../../types/meldekort';
 import { RootState } from '../../store/configureStore';
 import { selectFeilmelding, selectIngenTidligereMeldekort } from '../../selectors/ui';
 
@@ -40,16 +40,6 @@ interface MapDispatchToProps {
 type State = {
     windowSize: number;
 };
-
-export interface HistoriskeMeldekortRad {
-    meldekort: Meldekort;
-    periode: string;
-    dato: string;
-    mottatt: string;
-    status: string;
-    bruttobelop: string;
-    detaljer: string;
-}
 
 type Props = MapDispatchToProps&MapStateToProps;
 

--- a/src/app/sider/tidligereMeldekort/tidligereMeldekort.tsx
+++ b/src/app/sider/tidligereMeldekort/tidligereMeldekort.tsx
@@ -1,29 +1,29 @@
 import * as React from 'react';
-import { Innholdstittel } from 'nav-frontend-typografi';
-import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
-import Sprakvelger from '../../components/sprakvelger/sprakvelger';
-import Komponentlenke from '../../components/komponentlenke/komponentlenke';
-import { Dispatch } from 'redux';
-import { HistoriskeMeldekortActions } from '../../actions/historiskeMeldekort';
-import { connect } from 'react-redux';
-import Tabell from '../../components/tabell/tabell';
-import EtikettBase from 'nav-frontend-etiketter';
-import { HistoriskeMeldekortState } from '../../reducers/historiskeMeldekortReducer';
-import { history, RootState } from '../../store/configureStore';
-import { formaterDato, hentDatoPeriode, hentUkePeriode } from '../../utils/dates';
-import { Meldekort } from '../../types/meldekort';
-import { mapKortStatusTilTekst } from '../../utils/mapper';
-import { finnRiktigEtikettType } from '../../utils/statusEtikettUtil';
-import { hentIntl } from '../../utils/intlUtil';
-import { InnsendingActions } from '../../actions/innsending';
-import { BaksystemFeilmelding, IngenTidligereMeldekort } from '../../types/ui';
-import { selectFeilmelding, selectIngenTidligereMeldekort } from '../../selectors/ui';
 import AlertStripe from 'nav-frontend-alertstriper';
+import EtikettBase from 'nav-frontend-etiketter';
+import Komponentlenke from '../../components/komponentlenke/komponentlenke';
+import MobilTabell from '../../components/mobilTabell/mobilTabell';
 import NavFrontendSpinner from 'nav-frontend-spinner';
+import Sprakvelger from '../../components/sprakvelger/sprakvelger';
+import Tabell from '../../components/tabell/tabell';
 import UIAlertstripeWrapper from '../../components/feil/UIAlertstripeWrapper';
-import { formaterBelop } from '../../utils/numberFormat';
-import { MeldekortActions } from '../../actions/meldekort';
 import { AktivtMeldekortActions } from '../../actions/aktivtMeldekort';
+import { BaksystemFeilmelding, IngenTidligereMeldekort } from '../../types/ui';
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
+import { finnRiktigEtikettType } from '../../utils/statusEtikettUtil';
+import { formaterBelop } from '../../utils/numberFormat';
+import { formaterDato, hentDatoPeriode, hentUkePeriode } from '../../utils/dates';
+import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
+import { hentIntl } from '../../utils/intlUtil';
+import { HistoriskeMeldekortActions } from '../../actions/historiskeMeldekort';
+import { HistoriskeMeldekortState } from '../../reducers/historiskeMeldekortReducer';
+import { Innholdstittel } from 'nav-frontend-typografi';
+import { InnsendingActions } from '../../actions/innsending';
+import { mapKortStatusTilTekst } from '../../utils/mapper';
+import { Meldekort } from '../../types/meldekort';
+import { RootState } from '../../store/configureStore';
+import { selectFeilmelding, selectIngenTidligereMeldekort } from '../../selectors/ui';
 
 interface MapStateToProps {
     historiskeMeldekort: HistoriskeMeldekortState;
@@ -37,7 +37,11 @@ interface MapDispatchToProps {
     leggTilAktivtMeldekort: (meldekort: Meldekort) => void;
 }
 
-interface HistoriskeMeldekortRad {
+type State = {
+    windowSize: number;
+};
+
+export interface HistoriskeMeldekortRad {
     meldekort: Meldekort;
     periode: string;
     dato: string;
@@ -49,10 +53,13 @@ interface HistoriskeMeldekortRad {
 
 type Props = MapDispatchToProps&MapStateToProps;
 
-class TidligereMeldekort extends React.Component<Props> {
+class TidligereMeldekort extends React.Component<Props, State> {
     constructor(props: any) {
         super(props);
         this.props.hentHistoriskeMeldekort();
+        this.state = {
+            windowSize: window.innerWidth
+        };
     }
 
     hentRaderFraHistoriskeMeldekort = () => {
@@ -92,39 +99,18 @@ class TidligereMeldekort extends React.Component<Props> {
             {key: 'bruttobelop', label: <FormattedMessage id="overskrift.bruttoBelop" />, cell: 'bruttobelop'},
         ];
 
-        const returnerTabellRad = (header: {key: string, label: JSX.Element, cell: any}, rowData: HistoriskeMeldekortRad) => {
-            let tableD = 'data';
-            for (let i in rowData) {
-                if (i === header.key) {
-                    tableD = rowData[i];
-                }
-            }
+        const erDesktopEllerTablet = this.state.windowSize > 768;
 
-            return (
-                <tr key={header.key}>
-                    <th> {header.label} </th>
-                    <td> {tableD} </td>
-                </tr>
-            );
-        }
-
-            /*<Tabell
+        return erDesktopEllerTablet ? (
+            <Tabell
                 rows={rows}
                 columns={columns}
-            />*/
-        return (
-            <div className={'mobilTabell_alle'}>
-                {rows.map( allRowData => (
-                    <table key={allRowData.meldekort.meldekortId}>
-                        <tbody>
-                            {columns.map((colHeader) => (
-                                returnerTabellRad(colHeader, allRowData)
-                            ))}
-                        </tbody>
-                    </table>
-                ))
-                }
-            </div>
+            />
+        ) : (
+            <MobilTabell
+                rows={rows}
+                columns={columns}
+            />
         );
     }
 
@@ -145,10 +131,15 @@ class TidligereMeldekort extends React.Component<Props> {
             );
         }
     }
+    handleWindowSize = () =>
+        this.setState({
+            windowSize: window.innerWidth
+        })
 
     componentDidMount() {
         this.props.resetInnsending();
         this.props.hentHistoriskeMeldekort();
+        window.addEventListener('resize', this.handleWindowSize);
     }
 
     render() {

--- a/src/app/store/configureStore.tsx
+++ b/src/app/store/configureStore.tsx
@@ -6,7 +6,7 @@ import { createBrowserHistory } from 'history';
 import { persistStore, persistReducer } from 'redux-persist';
 import createEncryptor from 'redux-persist-transform-encrypt';
 
-import aktivtMeldekortReducer, { AktivtMeldekortState } from '../reducers/aktivtMeldekortReducer';
+import aktivtMeldekortReducer from '../reducers/aktivtMeldekortReducer';
 import historiskeMeldekortReducer, { HistoriskeMeldekortState } from '../reducers/historiskeMeldekortReducer';
 import meldekortdetaljerReducer, { MeldekortdetaljerState } from '../reducers/meldekortdetaljerReducer';
 import personReducer from '../reducers/personReducer';
@@ -31,6 +31,8 @@ import menyReducer from '../reducers/menyReducer';
 import meldeformReducer, { MeldeformState } from '../reducers/meldeformReducer';
 import meldeformEpics from '../epics/meldeformEpics';
 import { MeldekortTypeKeys } from '../actions/meldekort';
+import meldekortReducer from '../reducers/meldekortReducer';
+import { Meldekort, SendteMeldekortState } from '../types/meldekort';
 
 export const history = createBrowserHistory({
     basename: '/meldekort'
@@ -52,12 +54,14 @@ export interface RootState {
     person: Person;
     personStatus: PersonStatusState;
     meldekortdetaljer: MeldekortdetaljerState;
-    aktivtMeldekort: AktivtMeldekortState;
+    aktivtMeldekort: Meldekort;
     historiskeMeldekort: HistoriskeMeldekortState;
     innsending: InnsendingState;
     meldeform: MeldeformState;
     meny: MenyState;
     ui: UIState;
+    meldekort: SendteMeldekortState;
+
 }
 
 export type AppEpic = Epic<Action, Action, RootState>;
@@ -75,6 +79,7 @@ const appReducer = combineReducers({
     meny: menyReducer,
     meldeform: meldeformReducer,
     ui: uiReducer,
+    meldekort: meldekortReducer
 });
 
 const rootReducer = (state: any, action: any) => {

--- a/src/app/types/meldekort.tsx
+++ b/src/app/types/meldekort.tsx
@@ -10,6 +10,15 @@ export interface Meldekort {
     korrigerbart: boolean;
 }
 
+export interface SendteMeldekortState {
+    sendteMeldekort: SendtMeldekort[];
+}
+
+export interface SendtMeldekort {
+    meldekortId: number;
+    kortType: KortType;
+}
+
 // hentMeldekortDetaljer
 export interface Meldekortdetaljer {
     id: string;
@@ -29,6 +38,7 @@ export interface Meldeperiode {
     fra: Date;
     til: Date;
     kortKanSendesFra: Date;
+    kanKortSendes: boolean;
     periodeKode: string;
 }
 

--- a/src/app/types/meldekort.tsx
+++ b/src/app/types/meldekort.tsx
@@ -1,4 +1,8 @@
 /* INTERFACES */
+import { mapKortStatusTilTekst, mapKortTypeTilTekst } from '../utils/mapper';
+import { formaterDato } from '../utils/dates';
+import { formaterBelop } from '../utils/numberFormat';
+
 export interface Meldekort {
     meldekortId: number;
     kortType: KortType;
@@ -101,6 +105,24 @@ export interface MeldekortDag {
 
 export interface FravaerType {
     typeFravaer: FravaerTypeEnum;
+}
+
+export interface HistoriskeMeldekortRad {
+    meldekort: Meldekort;
+    periode?: string;
+    dato: string;
+    mottatt: string;
+    status: string;
+    bruttobelop: string;
+    detaljer?: string;
+}
+
+export interface DetaljRad {
+    meldekortid: number;
+    kortType: string;
+    kortStatus: string;
+    bruttoBelop: string;
+    mottattDato: any;
 }
 
 /* ENUMS */

--- a/src/app/utils/dates.tsx
+++ b/src/app/utils/dates.tsx
@@ -73,12 +73,6 @@ export const hentNestePeriodeMedUkerOgDato = (fraDato: Date, tilDato: Date): str
 
 };
 
-export const kanMeldekortSendesInn = (kortKanSendesFra: Date): boolean => {
-    let sendesFra = moment(kortKanSendesFra).hour(0).minute(0).second(0).format();
-    let dagensDato = moment(new Date()).hour(0).minute(0).second(0).format();
-    return moment(sendesFra).isSameOrBefore(dagensDato);
-};
-
 export const ukeTekst = () => {
     return hentIntl().formatMessage({id: 'overskrift.uke'});
 };

--- a/src/app/utils/meldekortUtils.tsx
+++ b/src/app/utils/meldekortUtils.tsx
@@ -1,0 +1,15 @@
+import { Meldekort, SendtMeldekort } from '../types/meldekort';
+
+export const erMeldekortSendtInnFor = (
+    meldekort: Meldekort,
+    sendteMeldekort: SendtMeldekort[]): boolean => {
+
+    let kanIkkeSendes = false;
+    for (let i = 0; i < sendteMeldekort.length; i++) {
+        if (sendteMeldekort[i].meldekortId === meldekort.meldekortId && sendteMeldekort[i].kortType === meldekort.kortType) {
+            kanIkkeSendes = true;
+            i = sendteMeldekort.length;
+        }
+    }
+    return kanIkkeSendes;
+};

--- a/src/index.less
+++ b/src/index.less
@@ -23,26 +23,22 @@
 @import "app/components/mobilMeny/mobilMeny.less";
 @import "app/components/mobilMeny/mobilMenyToggle.less";
 @import "app/components/modal/UIModalWrapper.less";
-@import "app/components/modal/UIModalWrapper.less";
 @import "app/components/print/printStyle.less";
 @import "app/components/sprakvelger/sprakvelger.less";
 @import "app/components/stegBanner/stegBanner.less";
-@import "app/components/stegBanner/stegBanner.less";
 @import "app/components/tabell/tabell.less";
-@import "app/components/tabell/tabell.less";
+@import "app/components/mobilTabell/mobilTabell.less";
 @import "app/components/utvidetinformasjon/infoToggler/infoToggler.less";
 @import "app/components/utvidetinformasjon/utvidetInformasjon.less";
 @import "app/sider/innsending/bekreftelsesside/bekreftelse.less";
 @import "app/sider/innsending/sporsmalsside/sporsmal/sporsmal.less";
 @import "app/sider/innsending/sporsmalsside/begrunnelse/begrunnelsesVelger.less";
 @import "app/sider/innsending/sporsmalsside/sporsmalsside.less";
-@import "app/sider/innsending/sporsmalsside/sporsmalsside.less";
 @import "app/sider/innsending/utfyllingsside/utfylling/aktivitet/aktivitetsrad.less";
 @import "app/sider/innsending/utfyllingsside/utfylling/arbeid/arbeidsrad.less";
 @import "app/sider/innsending/utfyllingsside/utfyllingsside.less";
 @import "app/sider/ofteStilteSporsmal/ofteStilteSporsmal.less";
 @import "app/sider/sendMeldekort/sendMeldekort.less";
-@import "app/sider/tidligereMeldekort/detaljer/detaljer.less";
 @import "app/sider/tidligereMeldekort/detaljer/detaljer.less";
 @import "app/sider/innsending/kvitteringsside/kvittering.less";
 


### PR DESCRIPTION
**Tabell for mobilskjerm**

- Lager en tokolonners tabell fra scratch når skjermen er mindre enn 768 piksler i bredde.
- Testet med skjermleser, og kan bekrefte at skjermleser fint klarer å lese av tabellen.
- Spesielt for tidligereMeldekort, så vil det byttes mellom mobiltabell og vanlig tabell basert på skjermbredde. mobiltabell vises ikke i SendMeldekort/etterregistrer fordi dataen som skal vises ikke er like stort på disse sidene. 
- detaljer til et meldekort viser nå tabellraden i mobiltabell pa mindre skjermer.
NB! Bor vurdere å tweake slik at det er en felles datatype som tas inn i tabellen slik at man kan spare specialcase koding som det er gjort for mobilTabell (for a kunne ta inn detaljRad og historiskeMeldekortRad[]). Tenker at man kan spare en del kodeinjer pa det. ![bitmoji]
![bitmoji](https://render.bitstrips.com/v2/cpanel/4f211e34-f0a8-4ad4-b294-4aadf9aa76b7-8e1a15a8-a790-4caf-b130-965b525e7a5a-v1.png?transparent=1&palette=1&width=246)

