### PR TITLE
Diverse feilfikser innsending

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -21,7 +21,6 @@ import { MenyPunkt } from './utils/menyConfig';
 import { MenyActions } from './actions/meny';
 import { Router } from './types/router';
 import { selectRouter } from './selectors/router';
-import { isEmpty } from 'ramda';
 import { hentIntl } from './utils/intlUtil';
 import classNames from 'classnames';
 import { PersonActions } from './actions/person';
@@ -105,24 +104,10 @@ class App extends React.Component<Props> {
         }
     }
 
-    /*settMenypunkterBasertPaPerson = (person: Person, menypunkter: MenyPunkt[]) => {
-        const menypunktliste = menypunkter.map(menypunkt => {
-            if (menypunkt.tittel === 'endreMeldeform') {
-                return {...menypunkt, disabled: person.meldeform !== MeldeForm.PAPIR};
-            } else if (menypunkt.tittel === 'etterregistrering') {
-                return {...menypunkt, disabled: isEmpty(person.etterregistrerteMeldekort)};
-            }
-            return menypunkt;
-        });
-
-        this.props.settMenyPunkter(menypunktliste);
-    }*/
-
     componentDidMount() {
         const { hentPersonStatus, hentPerson, person, meny, router  } = this.props;
         hentPersonStatus();
         this.settAktivMenuPunktBasertPaUrl(meny, router.location.pathname);
-        // this.settMenypunkterBasertPaPerson(person, meny.alleMenyPunkter);
     }
 
     public render() {

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -67,7 +67,9 @@ class App extends React.Component<Props> {
                 </div>
             );
         }  else if (erBrukerRegistrertIArena(this.props.personStatus.personStatus.statusArbeidsoker)) {
-            this.props.hentPerson();
+            if (this.props.person.personId === 0) {
+                this.props.hentPerson();
+            }
             return (
                 <div>
                     <Header tittel={hentIntl().formatMessage({id: 'overskrift.meldekort'})}/>
@@ -103,7 +105,7 @@ class App extends React.Component<Props> {
         }
     }
 
-    settMenypunkterBasertPaPerson = (person: Person, menypunkter: MenyPunkt[]) => {
+    /*settMenypunkterBasertPaPerson = (person: Person, menypunkter: MenyPunkt[]) => {
         const menypunktliste = menypunkter.map(menypunkt => {
             if (menypunkt.tittel === 'endreMeldeform') {
                 return {...menypunkt, disabled: person.meldeform !== MeldeForm.PAPIR};
@@ -114,13 +116,13 @@ class App extends React.Component<Props> {
         });
 
         this.props.settMenyPunkter(menypunktliste);
-    }
+    }*/
 
     componentDidMount() {
         const { hentPersonStatus, hentPerson, person, meny, router  } = this.props;
         hentPersonStatus();
         this.settAktivMenuPunktBasertPaUrl(meny, router.location.pathname);
-        this.settMenypunkterBasertPaPerson(person, meny.alleMenyPunkter);
+        // this.settMenypunkterBasertPaPerson(person, meny.alleMenyPunkter);
     }
 
     public render() {

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -49,10 +49,14 @@ interface MapDispatchToProps {
 
 type Props = MapDispatchToProps&MapStateToProps;
 
-class App extends React.Component<Props> {
+interface AppState {
+    henterPersonInfo: boolean;
+}
+
+class App extends React.Component<Props, AppState> {
     constructor(props: any) {
         super(props);
-
+        this.state = { henterPersonInfo: false };
         this.props.hentPersonStatus();
     }
 
@@ -66,8 +70,9 @@ class App extends React.Component<Props> {
                 </div>
             );
         }  else if (erBrukerRegistrertIArena(this.props.personStatus.personStatus.statusArbeidsoker)) {
-            if (this.props.person.personId === 0) {
+            if (this.props.person.personId === 0 && !this.state.henterPersonInfo) {
                 this.props.hentPerson();
+                this.setState({ henterPersonInfo: true });
             }
             return (
                 <div>

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -24,6 +24,8 @@ import { selectRouter } from './selectors/router';
 import { isEmpty } from 'ramda';
 import { hentIntl } from './utils/intlUtil';
 import classNames from 'classnames';
+import { PersonActions } from './actions/person';
+import { erBrukerRegistrertIArena } from './utils/meldekortUtils';
 
 if (erMock()) {
     setupMock();
@@ -38,6 +40,7 @@ interface MapStateToProps {
 }
 
 interface MapDispatchToProps {
+    hentPerson: () => void;
     hentPersonStatus: () => void;
     settValgtMenyPunkt: (menypunkt: MenyPunkt) => void;
     settMenyPunkter: ( menypunkter: MenyPunkt[]) => void;
@@ -54,11 +57,6 @@ class App extends React.Component<Props> {
         this.props.hentPersonStatus();
     }
 
-    erBrukerRegistrertIArena = (): boolean => {
-        let arbeidssokerStatus = this.props.personStatus.personStatus.statusArbeidsoker;
-        return !(arbeidssokerStatus === null || arbeidssokerStatus === '');
-    }
-
     settInnhold = () => {
         if (this.props.personStatus.personStatus.id === '') { // TODO: Denne testen burde kanskje endres. Må se an hvordan vi gjør det med feilhåndtering.
             return (
@@ -68,7 +66,8 @@ class App extends React.Component<Props> {
                 }
                 </div>
             );
-        }  else if (this.erBrukerRegistrertIArena()) {
+        }  else if (erBrukerRegistrertIArena(this.props.personStatus.personStatus.statusArbeidsoker)) {
+            this.props.hentPerson();
             return (
                 <div>
                     <Header tittel={hentIntl().formatMessage({id: 'overskrift.meldekort'})}/>
@@ -118,7 +117,7 @@ class App extends React.Component<Props> {
     }
 
     componentDidMount() {
-        const { hentPersonStatus, person, meny, router  } = this.props;
+        const { hentPersonStatus, hentPerson, person, meny, router  } = this.props;
         hentPersonStatus();
         this.settAktivMenuPunktBasertPaUrl(meny, router.location.pathname);
         this.settMenypunkterBasertPaPerson(person, meny.alleMenyPunkter);
@@ -148,6 +147,7 @@ const mapStateToProps = (state: RootState): MapStateToProps => {
 
 const mapDispatchToProps = (dispatch: Dispatch): MapDispatchToProps => {
     return {
+        hentPerson: () => dispatch(PersonActions.hentPerson.request()),
         hentPersonStatus: () => dispatch(PersonStatusActions.hentPersonStatus.request()),
         settValgtMenyPunkt: (menypunkt: MenyPunkt) => dispatch(MenyActions.settValgtMenyPunkt(menypunkt)),
         settMenyPunkter: (menypunkter: MenyPunkt[]) => dispatch(MenyActions.settAktiveMenyPunkter(menypunkter)),

--- a/src/app/components/header/header.tsx
+++ b/src/app/components/header/header.tsx
@@ -61,7 +61,7 @@ class Header extends React.Component<HeaderProps> {
     render() {
         const {router, tittel} = this.props;
         const params = router.location.pathname.split('/');
-        const harPathInnsending = params[params.length - 2] === 'innsending' || params[params.length - 2] === 'korrigering' ;
+        const harPathInnsending = params[params.length - 2] === 'innsending' || params[params.length - 2] === 'korriger' ;
         const headerClass = harPathInnsending ? 'meldekort-header__innsending' : 'meldekort-header';
 
         return (

--- a/src/app/components/header/header.tsx
+++ b/src/app/components/header/header.tsx
@@ -108,5 +108,4 @@ const mapDispatchToProps = (dispatch: Dispatch): MapDispatchToProps => {
     };
 };
 
-// Header.displayName = 'Header';
 export default connect(mapStateToProps, mapDispatchToProps)(Header);

--- a/src/app/components/header/header.tsx
+++ b/src/app/components/header/header.tsx
@@ -44,8 +44,6 @@ class Header extends React.Component<HeaderProps> {
     oppdatertMeny = () => {
          const { meny, person } = this.props;
          const oppdatertMeny = meny.alleMenyPunkter.map(menypunkt => {
-             console.log('TRIGGERD!');
-             console.log(person);
              if (menypunkt.tittel === 'endreMeldeform') {
                  return {...menypunkt, disabled: person.meldeform !== MeldeForm.PAPIR};
              } else if (menypunkt.tittel === 'etterregistrering') {

--- a/src/app/components/hovedMeny/hovedMeny.tsx
+++ b/src/app/components/hovedMeny/hovedMeny.tsx
@@ -6,6 +6,7 @@ import { hentIntl } from '../../utils/intlUtil';
 import { MenyActions } from '../../actions/meny';
 import { MenyPunkt } from '../../utils/menyConfig';
 import { RootState, history } from '../../store/configureStore';
+import { useEffect } from 'react';
 
 interface MapStateToProps {
     valgtMenyPunkt: MenyPunkt;

--- a/src/app/components/knapp/navKnapp.tsx
+++ b/src/app/components/knapp/navKnapp.tsx
@@ -74,7 +74,6 @@ class NavKnapp extends React.Component<Props> {
                 validert = this.props.validering();
             }
             if (validert) {
-                console.log('Validert!')
                 const path = router.location.pathname;
                 const params = path.split('/');
                 const nestePathParams = nestePath.split('/');

--- a/src/app/components/knapp/navKnapp.tsx
+++ b/src/app/components/knapp/navKnapp.tsx
@@ -81,12 +81,6 @@ class NavKnapp extends React.Component<Props> {
                 const erPaInnsending = innsendingstypeFraStore !== null;
                 let nyPath: string = '';
 
-                console.log('path: ', path);
-                console.log('params: ', params);
-                console.log('nestePathParams: ', nestePathParams);
-                console.log('erPaKvittering: ', erPaKvittering);
-                console.log('erPaInnsedning: ', erPaInnsending);
-
                 if (erPaInnsending) {
                     if (!erPaKvittering) {
                         nyPath = this.returnerNestePathInnenforInnsending(params, nestePathParams);

--- a/src/app/components/knapp/navKnapp.tsx
+++ b/src/app/components/knapp/navKnapp.tsx
@@ -81,6 +81,12 @@ class NavKnapp extends React.Component<Props> {
                 const erPaInnsending = innsendingstypeFraStore !== null;
                 let nyPath: string = '';
 
+                console.log('path: ', path);
+                console.log('params: ', params);
+                console.log('nestePathParams: ', nestePathParams);
+                console.log('erPaKvittering: ', erPaKvittering);
+                console.log('erPaInnsedning: ', erPaInnsending);
+
                 if (erPaInnsending) {
                     if (!erPaKvittering) {
                         nyPath = this.returnerNestePathInnenforInnsending(params, nestePathParams);
@@ -94,6 +100,8 @@ class NavKnapp extends React.Component<Props> {
                 }
                 if (this.harNestePathInnsending(nestePathParams) && nesteInnsendingstype !== undefined) {
                     this.props.settInnsendingstype(nesteInnsendingstype);
+                }
+                if (!erPaInnsending) {
                     nyPath = nestePath;
                 }
                 history.push(nyPath);

--- a/src/app/epics/personStatusEpics.tsx
+++ b/src/app/epics/personStatusEpics.tsx
@@ -1,7 +1,7 @@
 import { AppEpic } from '../store/configureStore';
 import { isActionOf } from 'typesafe-actions';
 import { PersonStatusActions } from '../actions/personStatus';
-import { catchError, concatMap, filter, map, switchMap } from 'rxjs/operators';
+import { catchError, filter, map, switchMap } from 'rxjs/operators';
 import { from, of } from 'rxjs';
 import { fetchPersonstatus } from '../api/api';
 import { combineEpics } from 'redux-observable';

--- a/src/app/epics/personStatusEpics.tsx
+++ b/src/app/epics/personStatusEpics.tsx
@@ -1,7 +1,7 @@
 import { AppEpic } from '../store/configureStore';
 import { isActionOf } from 'typesafe-actions';
 import { PersonStatusActions } from '../actions/personStatus';
-import { catchError, filter, map, switchMap } from 'rxjs/operators';
+import { catchError, concatMap, filter, map, switchMap } from 'rxjs/operators';
 import { from, of } from 'rxjs';
 import { fetchPersonstatus } from '../api/api';
 import { combineEpics } from 'redux-observable';

--- a/src/app/mock/responses/person.json
+++ b/src/app/mock/responses/person.json
@@ -4,7 +4,7 @@
   "etternavn": "MOCKESEN",
   "fornavn": "MOCK",
   "maalformkode": "NO",
-  "meldeform": "PAPIR",
+  "meldeform": "EMELD",
   "meldekort": [
     {
       "meldekortId": 1011121314,

--- a/src/app/sider/endreMeldeform/endreMeldeform.tsx
+++ b/src/app/sider/endreMeldeform/endreMeldeform.tsx
@@ -11,6 +11,7 @@ import { Dispatch } from 'redux';
 import { MeldeformActions } from '../../actions/meldeform';
 import { connect } from 'react-redux';
 import { MeldeformState } from '../../reducers/meldeformReducer';
+import { Redirect } from 'react-router';
 
 interface MapStateToProps {
     person: Person;
@@ -36,7 +37,7 @@ class EndreMeldeform extends React.Component<EndreMeldeformProps, any> {
     }
 
     render() {
-        return(
+        return this.props.person.meldeform === MeldeForm.PAPIR ? (
             <main className="sideinnhold">
                 <section className="seksjon flex-innhold tittel-sprakvelger">
                     <Innholdstittel> {hentIntl().formatMessage({id: 'overskrift.endreMeldeform'})} </Innholdstittel>
@@ -75,7 +76,7 @@ class EndreMeldeform extends React.Component<EndreMeldeformProps, any> {
                     />
                 </section>
             </main>
-        );
+        ) : <Redirect to="/om-meldekort"/>;
     }
 }
 

--- a/src/app/sider/etterregistrerMeldekort/etterregistrerMeldekort.tsx
+++ b/src/app/sider/etterregistrerMeldekort/etterregistrerMeldekort.tsx
@@ -11,16 +11,18 @@ import { connect } from 'react-redux';
 import { Router } from '../../types/router';
 import Tabell from '../../components/tabell/tabell';
 import NavKnapp, { knappTyper } from '../../components/knapp/navKnapp';
-import { KortStatus, Meldekort } from '../../types/meldekort';
+import { KortStatus, Meldekort, SendtMeldekort } from '../../types/meldekort';
 import { hentDatoPeriode, hentUkePeriode } from '../../utils/dates';
 import { Innsendingstyper } from '../../types/innsending';
 import { Person } from '../../types/person';
 import { Redirect } from 'react-router';
 import { AktivtMeldekortActions } from '../../actions/aktivtMeldekort';
+import { erMeldekortSendtInnFor } from '../../utils/meldekortUtils';
 
 interface MapStateToProps {
     person: Person;
     router: Router;
+    sendteMeldekort: SendtMeldekort[];
 }
 interface MapDispatchToProps {
     hentPerson: () => void;
@@ -53,28 +55,37 @@ class EtterregistrerMeldekort extends React.Component<Props, any> {
         if (typeof this.props.person.etterregistrerteMeldekort === 'undefined') {
             return [];
         }
-        return this.props.person.etterregistrerteMeldekort.filter((meldekortObj) =>
-            (meldekortObj.kortStatus === KortStatus.OPPRE || meldekortObj.kortStatus === KortStatus.SENDT) &&
-            (meldekortObj.meldeperiode.kanKortSendes));
+        return this.props.person.etterregistrerteMeldekort.filter((meldekortObj) => {
+            if (meldekortObj.kortStatus === KortStatus.OPPRE || meldekortObj.kortStatus === KortStatus.SENDT) {
+                if (meldekortObj.meldeperiode.kanKortSendes) {
+                    return !erMeldekortSendtInnFor(meldekortObj, this.props.sendteMeldekort);
+                }
+            }
+            return false;
+            });
     }
 
     hentMeldekortRaderFraPerson = () => {
-        let meldekortListe = this.props.person.etterregistrerteMeldekort;
+        let meldekortListe = this.filtrerMeldekortListe();
         let radliste = [];
         for (let i = 0; i < meldekortListe.length; i++) {
             if (meldekortListe[i].kortStatus === KortStatus.OPPRE || meldekortListe[i].kortStatus === KortStatus.SENDT) {
-                let rad: MeldekortRad = {
-                    periode: hentUkePeriode(meldekortListe[i].meldeperiode.fra, meldekortListe[i].meldeperiode.til),
-                    dato: hentDatoPeriode(meldekortListe[i].meldeperiode.fra, meldekortListe[i].meldeperiode.til),
-                };
-                radliste.push(rad);
+                if (meldekortListe[i].meldeperiode.kanKortSendes) {
+                    let rad: MeldekortRad = {
+                        periode: hentUkePeriode(meldekortListe[i].meldeperiode.fra, meldekortListe[i].meldeperiode.til),
+                        dato: hentDatoPeriode(meldekortListe[i].meldeperiode.fra, meldekortListe[i].meldeperiode.til),
+                    };
+                    radliste.push(rad);
+                }
             }
         }
         return radliste;
     }
 
     componentDidMount() {
-        this.props.resetInnsending();
+        if (this.filtrerMeldekortListe().length !== 1) {
+            this.props.resetInnsending();
+        }
         this.props.hentPerson();
     }
 
@@ -84,7 +95,6 @@ class EtterregistrerMeldekort extends React.Component<Props, any> {
             {key: 'periode', label: 'Periode'},
             {key: 'dato', label: 'Dato'}
         ];
-        const { etterregistrerteMeldekort } = this.props.person;
         const ettMeldekort = this.harEttMeldekort();
         return !ettMeldekort ? (
             <main className="sideinnhold">
@@ -109,7 +119,7 @@ class EtterregistrerMeldekort extends React.Component<Props, any> {
                         type={knappTyper.hoved}
                         nestePath={this.props.router.location.pathname + '/innsending'}
                         tekstid={'overskrift.etterregistrertMeldekort'}
-                        nesteAktivtMeldekort={etterregistrerteMeldekort[0]}
+                        nesteAktivtMeldekort={this.filtrerMeldekortListe()[0]}
                         nesteInnsendingstype={Innsendingstyper.etterregistrering}
                     />
                 </section>
@@ -122,6 +132,7 @@ const mapStateToProps = (state: RootState): MapStateToProps => {
     return {
         person: state.person,
         router: selectRouter(state),
+        sendteMeldekort: state.meldekort.sendteMeldekort
     };
 };
 

--- a/src/app/sider/etterregistrerMeldekort/etterregistrerMeldekort.tsx
+++ b/src/app/sider/etterregistrerMeldekort/etterregistrerMeldekort.tsx
@@ -96,7 +96,7 @@ class EtterregistrerMeldekort extends React.Component<Props, any> {
             {key: 'dato', label: 'Dato'}
         ];
         const ettMeldekort = this.harEttMeldekort();
-        return !ettMeldekort ? (
+        return rows.length === 0 ? <Redirect to="/om-meldekort"/> : (!ettMeldekort ? (
             <main className="sideinnhold">
                 <section className="seksjon flex-innhold tittel-sprakvelger">
                     <Innholdstittel className="seksjon"> {rows.length} meldekort klar for etteregistrering </Innholdstittel>
@@ -124,7 +124,7 @@ class EtterregistrerMeldekort extends React.Component<Props, any> {
                     />
                 </section>
             </main>
-        ) : <Redirect exact={true} from="/etterregistrer-meldekort" to="/etterregistrer-meldekort/innsending"/>;
+        ) : <Redirect exact={true} from="/etterregistrer-meldekort" to="/etterregistrer-meldekort/innsending"/>);
     }
 }
 

--- a/src/app/sider/etterregistrerMeldekort/etterregistrerMeldekort.tsx
+++ b/src/app/sider/etterregistrerMeldekort/etterregistrerMeldekort.tsx
@@ -17,7 +17,7 @@ import { Innsendingstyper } from '../../types/innsending';
 import { Person } from '../../types/person';
 import { Redirect } from 'react-router';
 import { AktivtMeldekortActions } from '../../actions/aktivtMeldekort';
-import { erMeldekortSendtInnFor } from '../../utils/meldekortUtils';
+import { erMeldekortSendtInnTidligere } from '../../utils/meldekortUtils';
 
 interface MapStateToProps {
     person: Person;
@@ -58,7 +58,7 @@ class EtterregistrerMeldekort extends React.Component<Props, any> {
         return this.props.person.etterregistrerteMeldekort.filter((meldekortObj) => {
             if (meldekortObj.kortStatus === KortStatus.OPPRE || meldekortObj.kortStatus === KortStatus.SENDT) {
                 if (meldekortObj.meldeperiode.kanKortSendes) {
-                    return !erMeldekortSendtInnFor(meldekortObj, this.props.sendteMeldekort);
+                    return !erMeldekortSendtInnTidligere(meldekortObj, this.props.sendteMeldekort);
                 }
             }
             return false;

--- a/src/app/sider/innsending/bekreftelsesside/bekreftelse.tsx
+++ b/src/app/sider/innsending/bekreftelsesside/bekreftelse.tsx
@@ -265,7 +265,7 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
                         />
                     </section>
                 </main>
-            ) : <Redirect exact={true} to="/send-meldekort"/>;
+            ) : <Redirect exact={true} to="/om-meldekort"/>;
         }
     }
 }

--- a/src/app/sider/innsending/bekreftelsesside/bekreftelse.tsx
+++ b/src/app/sider/innsending/bekreftelsesside/bekreftelse.tsx
@@ -19,7 +19,8 @@ import {
     Meldekort,
     MeldekortDag,
     Meldekortdetaljer as MDetaljer,
-    MeldekortdetaljerInnsending
+    MeldekortdetaljerInnsending,
+    SendtMeldekort
 } from '../../../types/meldekort';
 import { hentIntl } from '../../../utils/intlUtil';
 import { BekreftCheckboksPanel } from 'nav-frontend-skjema';
@@ -27,11 +28,13 @@ import { scrollTilElement } from '../../../utils/scroll';
 import { Dispatch } from 'redux';
 import { kalkulerDato } from '../../../utils/dates';
 import { Redirect } from 'react-router';
+import { erAktivtMeldekortGyldig } from '../../../utils/meldekortUtils';
 
 interface MapStateToProps {
     innsending: InnsendingState;
     aktivtMeldekort: Meldekort;
     person: Person;
+    sendteMeldekort: SendtMeldekort[];
 }
 
 interface MapDispatchToProps {
@@ -193,6 +196,7 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
     }
 
     render() {
+        let { aktivtMeldekort, sendteMeldekort } = this.props;
         let { meldegruppe } = this.props.aktivtMeldekort;
         let { valideringsResultat } = this.props.innsending;
         let { meldekortdetaljer } = this.state.meldekortdetaljer;
@@ -206,7 +210,7 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
                 <Redirect exact={true} from="send-meldekort/innsending/bekreft" to="kvittering"/>
             );
         } else {
-            return (
+            return erAktivtMeldekortGyldig(aktivtMeldekort, sendteMeldekort) ? (
                 <main>
                     <div className="ikkeSendt">
                         <AlertStripe type={'info'} solid={true}>
@@ -261,7 +265,7 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
                         />
                     </section>
                 </main>
-            );
+            ) : <Redirect exact={true} to="/send-meldekort"/>;
         }
     }
 }
@@ -271,6 +275,7 @@ const mapStateToProps = (state: RootState): MapStateToProps => {
         innsending: state.innsending,
         aktivtMeldekort: state.aktivtMeldekort,
         person: state.person,
+        sendteMeldekort: state.meldekort.sendteMeldekort
     };
 };
 

--- a/src/app/sider/innsending/kvitteringsside/kvittering.tsx
+++ b/src/app/sider/innsending/kvitteringsside/kvittering.tsx
@@ -24,7 +24,7 @@ import PrintKnapp from '../../../components/print/printKnapp';
 import AlertStripe from 'nav-frontend-alertstriper';
 import { scrollTilElement } from '../../../utils/scroll';
 import { MeldekortActions } from '../../../actions/meldekort';
-import { erMeldekortSendtInnFor } from '../../../utils/meldekortUtils';
+import { erMeldekortSendtInnTidligere } from '../../../utils/meldekortUtils';
 
 interface MapStateToProps {
     router: Router;
@@ -140,7 +140,7 @@ class Kvittering extends React.Component<KvitteringsProps> {
         return meldekortListe.filter(meldekort => {
             let kanSendes = meldekort.meldeperiode.kanKortSendes;
             if (kanSendes) {
-                kanSendes = !erMeldekortSendtInnFor(meldekort, this.props.sendteMeldekort.sendteMeldekort);
+                kanSendes = !erMeldekortSendtInnTidligere(meldekort, this.props.sendteMeldekort.sendteMeldekort);
             }
             return kanSendes;
         });

--- a/src/app/sider/innsending/kvitteringsside/kvittering.tsx
+++ b/src/app/sider/innsending/kvitteringsside/kvittering.tsx
@@ -81,8 +81,6 @@ class Kvittering extends React.Component<KvitteringsProps> {
         const nestePath = urlParams.join('/');
         const meldekort = this.meldekortSomKanSendes(person.meldekort);
         const etterregistrerteMeldekort = this.meldekortSomKanSendes(person.etterregistrerteMeldekort);
-        console.log('meldekort som kan sendes: ', meldekort);
-        console.log('etterregistrerteMeldekort som kan sendes: ', etterregistrerteMeldekort);
         const harBrukerFlereMeldekort = meldekort.length > 0;
         const harBrukerFlereEtterregistrerteMeldekort = etterregistrerteMeldekort.length > 0;
         const paramsForMeldekort = this.returnerMeldekortListaMedFlereMeldekortIgjen(

--- a/src/app/sider/innsending/sporsmalsside/begrunnelse/begrunnelseVelger.tsx
+++ b/src/app/sider/innsending/sporsmalsside/begrunnelse/begrunnelseVelger.tsx
@@ -43,7 +43,6 @@ const BegrunnelseVelger: React.FunctionComponent<Props> = (props) => {
 
     return (
         <div className={'seksjon begrunnelse ' + begrunnelseClass}>
-            {console.log('valgt arsak: ', valgtArsak)}
             <Select
                 label={
                     <>

--- a/src/app/sider/innsending/sporsmalsside/begrunnelse/begrunnelseVelger.tsx
+++ b/src/app/sider/innsending/sporsmalsside/begrunnelse/begrunnelseVelger.tsx
@@ -39,8 +39,11 @@ const BegrunnelseVelger: React.FunctionComponent<Props> = (props) => {
 
     const begrunnelseClass = props.erFeil ? 'feilmelding' : '';
 
+    const { valgtArsak } = props.begrunnelse;
+
     return (
         <div className={'seksjon begrunnelse ' + begrunnelseClass}>
+            {console.log('valgt arsak: ', valgtArsak)}
             <Select
                 label={
                     <>
@@ -53,10 +56,11 @@ const BegrunnelseVelger: React.FunctionComponent<Props> = (props) => {
                     </>
                 }
                 onChange={handleOnChange}
+                value={valgtArsak}
             >
                 <option value={''}> {hentIntl().formatMessage({id: 'begrunnelse.velgArsak'})}</option>
                 {options.map(opt => (
-                    <option key={opt}> {opt} </option>
+                    <option value={opt.trim()} key={opt}> {opt} </option>
                 ))}
             </Select>
             {props.erFeil && (<span className={'rodTekst'}>{hentIntl().formatMessage({id: 'begrunnelse.required'})}</span>)}

--- a/src/app/sider/innsending/sporsmalsside/sporsmalsside.tsx
+++ b/src/app/sider/innsending/sporsmalsside/sporsmalsside.tsx
@@ -17,15 +17,17 @@ import { ikkeFortsetteRegistrertContent } from '../../../components/modal/ikkeFo
 import { IModal, ModalKnapp } from '../../../types/ui';
 import { Innholdstittel } from 'nav-frontend-typografi';
 import { InnsendingActions } from '../../../actions/innsending';
-import { Meldegruppe, Meldekort } from '../../../types/meldekort';
-import { RouteComponentProps } from 'react-router';
+import { Meldegruppe, Meldekort, SendtMeldekort } from '../../../types/meldekort';
+import { Redirect, RouteComponentProps } from 'react-router';
 import { scrollTilElement } from '../../../utils/scroll';
 import { Sporsmal } from './sporsmal/sporsmalConfig';
 import { UiActions } from '../../../actions/ui';
+import { erAktivtMeldekortGyldig } from '../../../utils/meldekortUtils';
 
 interface MapStateToProps {
     aktivtMeldekort: Meldekort;
     innsending: InnsendingState;
+    sendteMeldekort: SendtMeldekort[];
 }
 
 interface MapDispatchToProps {
@@ -239,65 +241,63 @@ class Sporsmalsside extends React.Component<SporsmalssideProps, any> {
     }
 
     render() {
-        const { innsending, aktivtMeldekort } = this.props;
+        const { innsending, aktivtMeldekort, sendteMeldekort } = this.props;
         const meldegruppeErAAP = aktivtMeldekort.meldegruppe === Meldegruppe.ATTF;
         const brukermelding = hentIntl().formatMessage({id: 'meldekort.bruker.melding'});
-        return (
-            <main>
-                <section className="seksjon flex-innhold sentrert">
-                    {brukermelding.length > 1 ?
-                        <AlertStripe type={'info'}>
-                            {brukermelding}
-                        </AlertStripe> : null
-                    }
-                </section>
-                <section className="seksjon flex-innhold tittel-sprakvelger">
-                    <Innholdstittel ><FormattedMessage id="overskrift.steg1" /></Innholdstittel>
-                    <Sprakvelger/>
-                </section>
-                <section className="seksjon alert">
-                    <Veilederpanel kompakt={true} svg={<img alt="Veilder" src={veileder}/>}>
-                        <div className="item">
-                            <FormattedMessage id="sporsmal.lesVeiledning" />
-                        </div>
-                        <div className="item">
-                            <FormattedMessage id="sporsmal.ansvarForRiktigUtfylling" />
-                        </div>
-                    </Veilederpanel>
-                </section>
-                <section id="feilmelding" className="seksjon">
-                    {this.hentFeilmeldinger(meldegruppeErAAP)}
-                </section>
-                { innsending.innsendingstype === Innsendingstyper.korrigering && (
-                    <section className="seksjon">
-                        <BegrunnelseVelger AAP={meldegruppeErAAP} erFeil={innsending.begrunnelse.erFeil}/>
+        return erAktivtMeldekortGyldig(aktivtMeldekort, sendteMeldekort) ? (
+                <main>
+                    <section className="seksjon flex-innhold sentrert">
+                        {brukermelding.length > 1 ?
+                            <AlertStripe type={'info'}>
+                                {brukermelding}
+                            </AlertStripe> : null
+                        }
                     </section>
-                )}
-                <section className="seksjon">
-                    <SporsmalsGruppe AAP={meldegruppeErAAP} innsending={innsending}/>
-                    <AlertStripe type="info">
-                        <FormattedHTMLMessage id="sporsmal.registrertMerknad" />
-                    </AlertStripe>
-                </section>
-                <section className="seksjon flex-innhold sentrert">
-                    <NavKnapp
-                        type={knappTyper.hoved}
-                        nestePath={this.hoppeOverUtfylling() ? '/bekreftelse' : '/utfylling'}
-                        tekstid={'naviger.neste'}
-                        className={'navigasjonsknapp'}
-                        validering={this.valider}
-                    />
-                    <NavKnapp
-                        type={knappTyper.flat}
-                        nestePath={'/om-meldekort'}
-                        tekstid={'naviger.avbryt'}
-                        className={'navigasjonsknapp'}
-                    />
-                </section>
-
-            </main>
-        );
-
+                    <section className="seksjon flex-innhold tittel-sprakvelger">
+                        <Innholdstittel><FormattedMessage id="overskrift.steg1"/></Innholdstittel>
+                        <Sprakvelger/>
+                    </section>
+                    <section className="seksjon alert">
+                        <Veilederpanel kompakt={true} svg={<img alt="Veilder" src={veileder}/>}>
+                            <div className="item">
+                                <FormattedMessage id="sporsmal.lesVeiledning"/>
+                            </div>
+                            <div className="item">
+                                <FormattedMessage id="sporsmal.ansvarForRiktigUtfylling"/>
+                            </div>
+                        </Veilederpanel>
+                    </section>
+                    <section id="feilmelding" className="seksjon">
+                        {this.hentFeilmeldinger(meldegruppeErAAP)}
+                    </section>
+                    {innsending.innsendingstype === Innsendingstyper.korrigering && (
+                        <section className="seksjon">
+                            <BegrunnelseVelger AAP={meldegruppeErAAP} erFeil={innsending.begrunnelse.erFeil}/>
+                        </section>
+                    )}
+                    <section className="seksjon">
+                        <SporsmalsGruppe AAP={meldegruppeErAAP} innsending={innsending}/>
+                        <AlertStripe type="info">
+                            <FormattedHTMLMessage id="sporsmal.registrertMerknad"/>
+                        </AlertStripe>
+                    </section>
+                    <section className="seksjon flex-innhold sentrert">
+                        <NavKnapp
+                            type={knappTyper.hoved}
+                            nestePath={this.hoppeOverUtfylling() ? '/bekreftelse' : '/utfylling'}
+                            tekstid={'naviger.neste'}
+                            className={'navigasjonsknapp'}
+                            validering={this.valider}
+                        />
+                        <NavKnapp
+                            type={knappTyper.flat}
+                            nestePath={'/om-meldekort'}
+                            tekstid={'naviger.avbryt'}
+                            className={'navigasjonsknapp'}
+                        />
+                    </section>
+                </main>
+            ) : <Redirect exact={true} to="/send-meldekort"/>;
     }
 
     ikkeFortsetteRegistrertKnapper = (): ModalKnapp[] => {
@@ -325,7 +325,8 @@ class Sporsmalsside extends React.Component<SporsmalssideProps, any> {
 const mapStateToProps = (state: RootState): MapStateToProps => {
     return {
         aktivtMeldekort: state.aktivtMeldekort,
-        innsending: state.innsending
+        innsending: state.innsending,
+        sendteMeldekort: state.meldekort.sendteMeldekort
     };
 };
 

--- a/src/app/sider/innsending/sporsmalsside/sporsmalsside.tsx
+++ b/src/app/sider/innsending/sporsmalsside/sporsmalsside.tsx
@@ -297,7 +297,7 @@ class Sporsmalsside extends React.Component<SporsmalssideProps, any> {
                         />
                     </section>
                 </main>
-            ) : <Redirect exact={true} to="/send-meldekort"/>;
+            ) : <Redirect exact={true} to="/om-meldekort"/>;
     }
 
     ikkeFortsetteRegistrertKnapper = (): ModalKnapp[] => {

--- a/src/app/sider/innsending/utfyllingsside/utfyllingsside.tsx
+++ b/src/app/sider/innsending/utfyllingsside/utfyllingsside.tsx
@@ -11,15 +11,18 @@ import Konstanter from '../../../utils/consts';
 import { UtfyltDag } from './utfylling/utfyllingConfig';
 import { hentIntl } from '../../../utils/intlUtil';
 import AlertStripe from 'nav-frontend-alertstriper';
-import { Meldegruppe, Meldekort } from '../../../types/meldekort';
+import { Meldegruppe, Meldekort, SendtMeldekort } from '../../../types/meldekort';
 import { scrollTilElement } from '../../../utils/scroll';
 import UkePanel from '../../../components/ukepanel/ukepanel';
 import { Dispatch } from 'redux';
 import { InnsendingActions } from '../../../actions/innsending';
+import { erAktivtMeldekortGyldig } from '../../../utils/meldekortUtils';
+import { Redirect } from 'react-router';
 
 interface MapStateToProps {
     innsending: InnsendingState;
     aktivtMeldekort: Meldekort;
+    sendteMeldekort: SendtMeldekort[];
 }
 
 interface MapDispatchToProps {
@@ -170,9 +173,10 @@ class Utfyllingsside extends React.Component<UtfyllingssideProps, UtfyllingFeil>
     }
 
     render() {
-        let { meldeperiode } = this.props.aktivtMeldekort;
+        let { aktivtMeldekort, sendteMeldekort } = this.props;
+        let { meldeperiode } = aktivtMeldekort;
 
-        return(
+        return erAktivtMeldekortGyldig(aktivtMeldekort, sendteMeldekort) ? (
             <main>
                 <section id="tittel" className="seksjon flex-innhold tittel-sprakvelger">
                     <Innholdstittel><FormattedMessage id="overskrift.steg2" /></Innholdstittel>
@@ -219,7 +223,7 @@ class Utfyllingsside extends React.Component<UtfyllingssideProps, UtfyllingFeil>
                     />
                 </section>
             </main>
-        );
+        ) : <Redirect exact={true} to="/send-meldekort"/>;
 
     }
 }
@@ -228,6 +232,7 @@ const mapStateToProps = (state: RootState): MapStateToProps => {
     return {
         innsending: state.innsending,
         aktivtMeldekort: state.aktivtMeldekort,
+        sendteMeldekort: state.meldekort.sendteMeldekort
     };
 };
 

--- a/src/app/sider/innsending/utfyllingsside/utfyllingsside.tsx
+++ b/src/app/sider/innsending/utfyllingsside/utfyllingsside.tsx
@@ -223,7 +223,7 @@ class Utfyllingsside extends React.Component<UtfyllingssideProps, UtfyllingFeil>
                     />
                 </section>
             </main>
-        ) : <Redirect exact={true} to="/send-meldekort"/>;
+        ) : <Redirect exact={true} to="/om-meldekort"/>;
 
     }
 }

--- a/src/app/sider/sendMeldekort/sendMeldekort.tsx
+++ b/src/app/sider/sendMeldekort/sendMeldekort.tsx
@@ -21,7 +21,7 @@ import { Redirect } from 'react-router';
 import { selectRouter } from '../../selectors/router';
 import { Person } from '../../types/person';
 import { AktivtMeldekortActions } from '../../actions/aktivtMeldekort';
-import { erMeldekortSendtInnFor } from '../../utils/meldekortUtils';
+import { erMeldekortSendtInnTidligere } from '../../utils/meldekortUtils';
 import Veilederpanel from 'nav-frontend-veilederpanel';
 import veileder from '../../ikoner/veileder.svg';
 
@@ -66,7 +66,7 @@ class SendMeldekort extends React.Component<Props, any> {
         return this.props.person.meldekort.filter((meldekortObj) => {
                 if (meldekortObj.kortStatus === KortStatus.OPPRE || meldekortObj.kortStatus === KortStatus.SENDT) {
                     if (meldekortObj.meldeperiode.kanKortSendes) {
-                        return !erMeldekortSendtInnFor(meldekortObj, this.props.sendteMeldekort);
+                        return !erMeldekortSendtInnTidligere(meldekortObj, this.props.sendteMeldekort);
                     }
                 }
                 return false;

--- a/src/app/sider/sendMeldekort/sendMeldekort.tsx
+++ b/src/app/sider/sendMeldekort/sendMeldekort.tsx
@@ -115,7 +115,6 @@ class SendMeldekort extends React.Component<Props, any> {
             let meldekort = meldekortliste.filter((m) => m.meldekortId === meldekortId);
             let meldekortSomIkkeKanSendesEnda = this.meldekortSomIkkeKanSendesInnEnda();
             if (meldekort.length === 0 && meldekortSomIkkeKanSendesEnda.length !== 0) {
-                console.log(meldekortSomIkkeKanSendesEnda);
                 return (
                     <div className="send-meldekort-varsel">
                         <Normaltekst>

--- a/src/app/utils/meldekortUtils.tsx
+++ b/src/app/utils/meldekortUtils.tsx
@@ -1,6 +1,6 @@
 import { Meldekort, SendtMeldekort } from '../types/meldekort';
 
-export const erMeldekortSendtInnFor = (
+export const erMeldekortSendtInnTidligere = (
     meldekort: Meldekort,
     sendteMeldekort: SendtMeldekort[]): boolean => {
 
@@ -12,4 +12,13 @@ export const erMeldekortSendtInnFor = (
         }
     }
     return kanIkkeSendes;
+};
+
+export const erAktivtMeldekortGyldig = (
+    meldekort: Meldekort,
+    sendteMeldekort: SendtMeldekort[]): boolean => {
+    if (meldekort.meldekortId !== 0) {
+        return !erMeldekortSendtInnTidligere(meldekort, sendteMeldekort);
+    }
+    return false;
 };

--- a/src/app/utils/meldekortUtils.tsx
+++ b/src/app/utils/meldekortUtils.tsx
@@ -22,3 +22,7 @@ export const erAktivtMeldekortGyldig = (
     }
     return false;
 };
+
+export const erBrukerRegistrertIArena = (arbeidssokerStatus: string): boolean => {
+    return !(arbeidssokerStatus === null || arbeidssokerStatus === '');
+};


### PR DESCRIPTION
- Endret måten vi setter aktivt meldekort
- Lagede en sjekk for sendte meldekort på kvitteringssiden og send meldekort/etterregistrer meldekort. Det gjør at sendte meldekort blir filtrert ut.
- I innsendingsløpet: Sjekker aktivt meldekort på hver side og redirecte til "om meldekort" hvis det ikke finnes eller det ikke kan sendes inn.
- Fikse feil i begrunnelse (ARB-123)
- Fikset "neste meldekort"-knapp på kvitteringssiden.
- Sperrer sider som bruker ikke har tilgang til (etterregistrere meldekort/endre meldeform)
- Menypunkter blir nå oppdatert når person lastes.
- Meny på korrigering er tatt bort