### PR TITLE
ARB-166 utskrift

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
   </head>
   <body>
     <noscript>
-      You need to enable JavaScript to run this app.
+      Du må skru på JavaScript for å bruke denne appen. / You need to enable JavaScript to run this app.
     </noscript>
     <div id="meldekort-root"></div>
   </body>

--- a/src/app/components/print/printStyle.less
+++ b/src/app/components/print/printStyle.less
@@ -3,6 +3,11 @@
 }
 
 @media print {
+  @page {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
   header,
   nav,
   footer,
@@ -26,6 +31,7 @@
       margin-bottom: 2vh;
 
       img {
+        margin-top: 1rem;
         margin-bottom: 1rem;
       }
     }

--- a/src/app/components/print/printStyle.less
+++ b/src/app/components/print/printStyle.less
@@ -117,7 +117,7 @@
             margin-bottom: 0.5rem;
             .dagliste__dager {
               .cssgrid();
-              grid-template-columns: 3rem auto;
+              grid-template-columns: 4.25rem auto;
               .ukedag {
               }
               .aktiviteter {

--- a/src/app/sider/tidligereMeldekort/detaljer/detaljer.less
+++ b/src/app/sider/tidligereMeldekort/detaljer/detaljer.less
@@ -1,4 +1,3 @@
-
 .innhold-detaljer {
   img {
     height: 3rem;
@@ -12,4 +11,18 @@
 
 .tabell-detaljer {
   margin-top: 3rem;
+}
+
+.ikkeVis {
+  display: none !important;
+}
+
+.ikkeVisMenPrint {
+  display: none;
+}
+
+@media print {
+  .ikkeVisMenPrint {
+    display: block;
+  }
 }

--- a/src/app/sider/tidligereMeldekort/detaljer/detaljer.less
+++ b/src/app/sider/tidligereMeldekort/detaljer/detaljer.less
@@ -14,7 +14,7 @@
 }
 
 .ikkeVis {
-  display: none !important;
+  display: none;
 }
 
 .ikkeVisMenPrint {

--- a/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
+++ b/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
@@ -101,7 +101,10 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
     ];
     const { meldegruppe } = aktivtMeldekort;
 
-    const erDesktopEllerTablet = this.state.windowSize > 768;
+    const erDesktop = this.state.windowSize > 768;
+
+    const mobilTabellStyle = classNames('noPrint', { ikkeVis: erDesktop });
+    const vanligTabellStylle = classNames({ ikkeVisMenPrint: !erDesktop });
 
     return (
       <>
@@ -109,11 +112,12 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
         <PeriodeBanner />
         <section className="seksjon">
           <div className="tabell-detaljer">
-            {erDesktopEllerTablet ? (
+            <div className={vanligTabellStylle}>
               <Tabell rows={[rows]} columns={columns} />
-            ) : (
+            </div>
+            <div className={mobilTabellStyle}>
               <MobilTabell row={rows} columns={columns} />
-            )}
+            </div>
           </div>
         </section>
         <section className="seksjon">

--- a/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
+++ b/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
@@ -104,7 +104,7 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
     const erDesktop = this.state.windowSize > 768;
 
     const mobilTabellStyle = classNames('noPrint', { ikkeVis: erDesktop });
-    const vanligTabellStylle = classNames({ ikkeVisMenPrint: !erDesktop });
+    const vanligTabellStyle = classNames({ ikkeVisMenPrint: !erDesktop });
 
     return (
       <>
@@ -112,7 +112,7 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
         <PeriodeBanner />
         <section className="seksjon">
           <div className="tabell-detaljer">
-            <div className={vanligTabellStylle}>
+            <div className={vanligTabellStyle}>
               <Tabell rows={[rows]} columns={columns} />
             </div>
             <div className={mobilTabellStyle}>


### PR DESCRIPTION
1. Fjerner mobiltabell fra detaljersiden ved utskrift og viser heller vanlig tabell. Dette gjør at innholdet på siden holdes innenfor 1 side.
2. Fjerner marginer på utskrift (sidemarginer, over og under) slik at tittel, url, dato osv ikke vises. Dette fungerer ikke i Safari.
3. Lager litt bedre plass for ukedag-teksten opå utskrift så ukedag-teksten ikke overlapper med aktiviteten på engelsk.