### PR TITLE
Innsendt MK i produksjon ble ikke logget i juridisk logg

### DIFF
--- a/src/app/sider/innsending/3-bekreftelsesside/bekreftelse.tsx
+++ b/src/app/sider/innsending/3-bekreftelsesside/bekreftelse.tsx
@@ -137,7 +137,7 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
       korrigerbart: this.props.innsending.innsendingstype !== Innsendingstyper.korrigering,
       begrunnelse: meldekortdetaljer.begrunnelse,
       signatur: meldekortdetaljer.sporsmal.signatur,
-      sesjonsId: '',
+      sesjonsId: 'IKKE I BRUK',
       fravaersdager: this.hentFravaersdager(meldekortdetaljer, aktivtMeldekort),
     };
   };


### PR DESCRIPTION
Da sesjonsid er tom når man sender meldekort feiler insert av juridisk logg i DB. Setter derfor sesjonsid til IKKE I BRUK