### PR TITLE
Stegindikator vises over global mobilmeny

### DIFF
--- a/src/app/components/stegBanner/stegBanner.less
+++ b/src/app/components/stegBanner/stegBanner.less
@@ -5,3 +5,7 @@
     }
   }
 }
+
+.stegindikator__steg {
+  z-index: 0;
+}


### PR DESCRIPTION
Fikset ved å legge til z-index: 0 på klassen .stegindikator__steg.