### PR TITLE
Arb 174 blank side

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -23,8 +23,8 @@ resources:
     cpu: 3
     memory: 1024Mi
   requests:
-    cpu: 200m
-    memory: 512Mi
+    cpu: 500m
+    memory: 768Mi
 fasitResources:
   used:
     - alias: appres.cms

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "start:mock": "cross-env REACT_APP_MOCK_FULL=true npm run start",
     "prettier": "`prettier '**/*.{js, tsx,less}'  --write`",
     "test": "CI=true react-scripts test --env=jsdom",
-    "test:watch": "react-scripts test --env=jsdom"
+    "test:watch": "react-scripts test --env=jsdom",
+    "test:reload": "react-scripts test -u"
   },
   "browserslist": [
     ">0.2%",

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
+    <!-- Intl polyfill -->
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.nb,Intl.~locale.en"></script>
     <!-- Konfig for appdynamics -->
     <script src="./appdynamics.js" charset='UTF-8'></script>
     <script src='https://jsagent.nav.no/adrum/adrum.js'></script>

--- a/src/__test__/components/__snapshots__/periodeBanner.snapshot.test.tsx.snap
+++ b/src/__test__/components/__snapshots__/periodeBanner.snapshot.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`PeriodeBanner 1`] = `
 <section
   className="seksjon periodeBanner "
+  id="periodebanner"
 >
   <p
     className="typo-ingress flex-innhold sentrert"

--- a/src/app/components/meldekortdetaljer/begrunnelsevisning/begrunnelse.tsx
+++ b/src/app/components/meldekortdetaljer/begrunnelsevisning/begrunnelse.tsx
@@ -8,18 +8,20 @@ interface Props {
   begrunnelse: string;
 }
 
-const BegrunnelseVisning: React.FunctionComponent<Props> = (props) => {
+const BegrunnelseVisning: React.FunctionComponent<Props> = props => {
   if (typeof props.begrunnelse !== 'undefined') {
     const begrunnelse = String(props.begrunnelse);
     if (begrunnelse.length > 0) {
       return (
-        <section className="seksjon begrunnelse">
-          <Undertittel>
-            <FormattedMessage id={'korrigering.sporsmal.begrunnelse'} />
-          </Undertittel>
-          <UtvidetInformasjon>
-            <FormattedHTMLMessage id={'forklaring.sporsmal.begrunnelse'} />
-          </UtvidetInformasjon>
+        <section className="begrunnelse">
+          <div className="sporsmalstekst">
+            <Undertittel>
+              <FormattedMessage id={'korrigering.sporsmal.begrunnelse'} />
+            </Undertittel>
+            <UtvidetInformasjon>
+              <FormattedHTMLMessage id={'forklaring.sporsmal.begrunnelse'} />
+            </UtvidetInformasjon>
+          </div>
           <img className={'checkmark'} alt={'checkmark'} src={checkMark} />
           <span>{props.begrunnelse}</span>
         </section>

--- a/src/app/components/meldekortdetaljer/meldekortdetaljer.less
+++ b/src/app/components/meldekortdetaljer/meldekortdetaljer.less
@@ -6,17 +6,18 @@
     margin-bottom: 2rem;
     border-bottom: 1px solid #d1d1d1;
 
-    .seksjon {
+    .begrunnelse {
       margin-bottom: 1rem;
-      &.begrunnelse {
-        padding-bottom: 1rem;
-        border-bottom: 1px solid #d1d1d1;
-        .utvidetInformasjon {
-          margin-top: 0.15rem;
-        }
-        .checkmark {
-          margin-right: 0.5rem;
-        }
+
+      .sporsmalstekst {
+        margin-bottom: 1rem;
+      }
+      .checkmark {
+        height: 24px;
+        margin-right: 0.5rem;
+      }
+      .utvidetInformasjon {
+        margin-top: 0.15rem;
       }
     }
 

--- a/src/app/components/periodeBanner/periodeBanner.tsx
+++ b/src/app/components/periodeBanner/periodeBanner.tsx
@@ -22,7 +22,10 @@ const PeriodeBanner: React.FunctionComponent<Props> = props => {
   const { meldeperiode } = props.aktivtMeldekort;
   const { className = '' } = props;
   return (
-    <section className={'seksjon periodeBanner ' + className}>
+    <section
+      id="periodebanner"
+      className={'seksjon periodeBanner ' + className}
+    >
       <Ingress className="flex-innhold sentrert">
         <FormattedMessage id="meldekort.for.perioden" />
       </Ingress>

--- a/src/app/mock/responses/meldekortdetaljer.json
+++ b/src/app/mock/responses/meldekortdetaljer.json
@@ -7,6 +7,7 @@
   "kortType": "ELEKTRONISK",
   "meldeDato": "2018-12-26T12:00:00+01:00",
   "lestDato": "2018-12-26T12:00:00+01:00",
+  "begrunnelse": "Syk",
   "sporsmal": {
     "arbeidssoker": true,
     "arbeidet": true,

--- a/src/app/sider/innsending/1-sporsmalsside/sporsmalsside.less
+++ b/src/app/sider/innsending/1-sporsmalsside/sporsmalsside.less
@@ -1,0 +1,3 @@
+.alertstripe_registrert {
+  margin-top: -1rem;
+}

--- a/src/app/sider/innsending/1-sporsmalsside/sporsmalsside.tsx
+++ b/src/app/sider/innsending/1-sporsmalsside/sporsmalsside.tsx
@@ -392,9 +392,11 @@ class Sporsmalsside extends React.Component<SporsmalssideProps, any> {
         <section className="seksjon">
           <SporsmalsGruppe AAP={meldegruppeErAAP} innsending={innsending} />
           {innsending.innsendingstype === Innsendingstyper.innsending ? (
-            <AlertStripe type="advarsel">
-              <FormattedHTMLMessage id="sporsmal.registrertMerknad" />
-            </AlertStripe>
+            <div className="alertstripe_registrert">
+              <AlertStripe type="advarsel">
+                <FormattedHTMLMessage id="sporsmal.registrertMerknad" />
+              </AlertStripe>
+            </div>
           ) : null}
         </section>
         <section className="seksjon flex-innhold sentrert">

--- a/src/app/sider/innsending/2-utfyllingsside/utfylling/arbeid/arbeidsrad.tsx
+++ b/src/app/sider/innsending/2-utfyllingsside/utfylling/arbeid/arbeidsrad.tsx
@@ -113,6 +113,7 @@ class Arbeidsrad extends React.Component<ArbeidsradProps> {
           bredde="XS"
           step={0.5}
           type={'text'}
+          inputMode={'numeric'}
           value={
             typeof utfylteDager[utfyltDagIndex].arbeidetTimer !== 'undefined'
               ? utfylteDager[utfyltDagIndex].arbeidetTimer

--- a/src/app/sider/innsending/2-utfyllingsside/utfylling/arbeid/arbeidsrad.tsx
+++ b/src/app/sider/innsending/2-utfyllingsside/utfylling/arbeid/arbeidsrad.tsx
@@ -113,7 +113,6 @@ class Arbeidsrad extends React.Component<ArbeidsradProps> {
           bredde="XS"
           step={0.5}
           type={'text'}
-          inputMode={'numeric'}
           value={
             typeof utfylteDager[utfyltDagIndex].arbeidetTimer !== 'undefined'
               ? utfylteDager[utfyltDagIndex].arbeidetTimer

--- a/src/app/tekster/hjelpetekster/forklaring.sporsmal.aktivitetArbeid-AAP_en.txt
+++ b/src/app/tekster/hjelpetekster/forklaring.sporsmal.aktivitetArbeid-AAP_en.txt
@@ -3,7 +3,7 @@ Click <strong>Yes</strong> if you have participated in activities you and NAV ag
 <br>
 This includes
 <ul>
-    <li>employment schemes</li>s
+    <li>employment schemes</li>
     <li>active medical treatment</li>
     <li>training or education</li>
     <li>other activities.</li>

--- a/src/app/tekster/hjelpetekster/sporsmal.lesVeiledning_en.txt
+++ b/src/app/tekster/hjelpetekster/sporsmal.lesVeiledning_en.txt
@@ -1,1 +1,1 @@
-You must read the guidance notes before filling out the fields in the employment status form. You will find these by clicking on the question marks.
+You must read the guidance notes before filling out the fields in the employment status form. You will find these by clicking "Read more" under each question.

--- a/src/app/tekster/hjelpetekster/sporsmal.lesVeiledning_nb.txt
+++ b/src/app/tekster/hjelpetekster/sporsmal.lesVeiledning_nb.txt
@@ -1,1 +1,1 @@
-Du må lese veiledningstekstene før du fyller ut feltene i meldekortet. Du finner dem ved å klikke på spørsmålstegnene.
+Du må lese veiledningstekstene før du fyller ut feltene i meldekortet. Du finner dem ved å klikke på "Les mer" under hvert spørsmål.

--- a/src/app/tekster/kompilerte-tekster.ts
+++ b/src/app/tekster/kompilerte-tekster.ts
@@ -268,7 +268,7 @@
     'sporsmal.ingenMeldekortASende':
       'Det er ingen tilgjengelige meldekort å sende inn ',
     'sporsmal.lesVeiledning':
-      'Du må lese veiledningstekstene før du fyller ut feltene i meldekortet. Du finner dem ved å klikke på spørsmålstegnene. ',
+      'Du må lese veiledningstekstene før du fyller ut feltene i meldekortet. Du finner dem ved å klikke på "Les mer" under hvert spørsmål. ',
     'sporsmal.registrertMerknad':
       'Merk: Hvis du svarer <strong>Nei</strong> vil du ikke lenger få bistand eller utbetalinger fra NAV ',
     'sporsmal.registrert':
@@ -392,7 +392,7 @@
     'feilmelding.baksystem':
       'We are having problems with our systems, and therefore can not show you your employment status forms. Please try again later. ',
     'forklaring.sporsmal.aktivitetArbeid-AAP':
-      'Click <strong>Yes</strong> if you have participated in activities you and NAV agreed on. <br> <br> This includes <ul>     <li>employment schemes</li>s     <li>active medical treatment</li>     <li>training or education</li>     <li>other activities.</li> </ul> <br> <br> Click <strong>Yes</strong> if you take part in activities you and NAV have not agreed on. This includes <ul>     <li>courses and/or training </li>     <li>Education </li>     <li>Self-study </li> </ul> Click <strong>No</strong> if you have not performed the agreed activity. <br> <br> Click <strong>No</strong> if you do not have any agreed activities during the term on the report card. This also applies if you have no other course or education planned in this period of time. ',
+      'Click <strong>Yes</strong> if you have participated in activities you and NAV agreed on. <br> <br> This includes <ul>     <li>employment schemes</li>     <li>active medical treatment</li>     <li>training or education</li>     <li>other activities.</li> </ul> <br> <br> Click <strong>Yes</strong> if you take part in activities you and NAV have not agreed on. This includes <ul>     <li>courses and/or training </li>     <li>Education </li>     <li>Self-study </li> </ul> Click <strong>No</strong> if you have not performed the agreed activity. <br> <br> Click <strong>No</strong> if you do not have any agreed activities during the term on the report card. This also applies if you have no other course or education planned in this period of time. ',
     'forklaring.sporsmal.aktivitetArbeid':
       'Click <strong>Yes</strong> if you have participated in employment schemes, courses or training/education. With employment schemes we mean labour market schemes such as an AMO course or a  Job Club. Do not record other activities from your activity plan, such as information meetings with NAV or jobs you have applied for. <br> <br> Click <strong>Yes</strong> if NAV has approved you receiving unemployment benefits while attending education. <br> <br> Click <strong>Yes</strong> if you have attended courses or education that you have not agreed upon with NAV. This also applies to self-study. <br> <br> Click <strong>No</strong> If you have not participated in employment schemes, courses or training/education. ',
     'forklaring.sporsmal.arbeid-AAP':
@@ -624,7 +624,7 @@
     'sporsmal.ingenMeldekortASende':
       'There are no available employment status form to send. ',
     'sporsmal.lesVeiledning':
-      'You must read the guidance notes before filling out the fields in the employment status form. You will find these by clicking on the question marks. ',
+      'You must read the guidance notes before filling out the fields in the employment status form. You will find these by clicking "Read more" under each question. ',
     'sporsmal.registrertMerknad':
       'Note: If you click <strong>No</strong>, you will no longer receive assistance or benefits. ',
     'sporsmal.registrert':

--- a/src/app/utils/scroll.tsx
+++ b/src/app/utils/scroll.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 export function scrollTilElement(
   elementid?: string,
   oppforsel: ScrollBehavior = 'smooth'
@@ -10,8 +12,18 @@ export function scrollTilElement(
       window.scrollY;
   }
 
-  window.scroll({
-    top: elementPos,
-    behavior: typeof oppforsel === 'undefined' ? 'smooth' : oppforsel,
-  });
+  try {
+    window.scroll({
+      top: elementPos,
+      behavior: typeof oppforsel === 'undefined' ? 'smooth' : oppforsel,
+    });
+  } catch (e) {
+    try {
+      if (typeof elementid !== 'undefined') {
+        document.getElementById(elementid)!.scrollIntoView();
+      }
+    } catch (e) {
+      console.log('Kunne ikke scrolle');
+    }
+  }
 }

--- a/src/app/utils/scroll.tsx
+++ b/src/app/utils/scroll.tsx
@@ -19,9 +19,10 @@ export function scrollTilElement(
     });
   } catch (e) {
     try {
-      if (typeof elementid !== 'undefined') {
-        document.getElementById(elementid)!.scrollIntoView();
+      if (typeof elementid === 'undefined') {
+        elementid = 'periodebanner';
       }
+      document.getElementById(elementid)!.scrollIntoView();
     } catch (e) {
       console.log('Kunne ikke scrolle');
     }


### PR DESCRIPTION
Fant ut at scrollTo ikke er støttet av eldre browsere. La derfor til en fallback med element.scrollIntoView. Har også lagt til rette for at sidene ikke crasher helt selv om disse to metodene ikke støttes.

Endret noe tekst etter ønske fra produkteier.

Fikset styling på advarsel om fortsette å være registrert.

Fikset størrelsen på checkmarkbildet i begrunnelse.

~~Fikset det slik at man får opp talltastatur på mobiler når man fyller ut antall timer arbeidet.~~ (Noen android-versjoner gir ikke brukeren tilgang til komma og/eller punktum med talltastatur. Fjerner derfor denne funkjonaliteten.)