### PR TITLE
Meldekortid er 0

### DIFF
--- a/src/app/actions/aktivtMeldekort.tsx
+++ b/src/app/actions/aktivtMeldekort.tsx
@@ -3,15 +3,15 @@ import { ActionType, createStandardAction } from 'typesafe-actions';
 
 export enum AktivtMeldekortTypeKeys {
   LEGG_TIL_AKTIVT_MELDEKORT = 'LEGG_TIL_AKTIVT_MELDEKORT',
-  RESET_AKTIVT_MELDEKORT = 'RESET_AKTIVT_MELDEKORT',
+  RESETT_AKTIVT_MELDEKORT = 'RESETT_AKTIVT_MELDEKORT',
 }
 
 export const AktivtMeldekortActions = {
   oppdaterAktivtMeldekort: createStandardAction(
     AktivtMeldekortTypeKeys.LEGG_TIL_AKTIVT_MELDEKORT
   )<Meldekort>(),
-  resetAktivtMeldekort: createStandardAction(
-    AktivtMeldekortTypeKeys.RESET_AKTIVT_MELDEKORT
+  resettAktivtMeldekort: createStandardAction(
+    AktivtMeldekortTypeKeys.RESETT_AKTIVT_MELDEKORT
   )<void>(),
 };
 

--- a/src/app/actions/meldekortdetaljer.tsx
+++ b/src/app/actions/meldekortdetaljer.tsx
@@ -19,7 +19,7 @@ export const MeldekortdetaljerActions = {
     MeldekortdetaljerTypeKeys.HENT_MELDEKORTDETALJER_OK,
     MeldekortdetaljerTypeKeys.HENT_MELDEKORTDETALJER_FEILET
   )<void, Meldekortdetaljer, AxiosError>(),
-  resetMeldekortdetaljer: createStandardAction(
+  resettMeldekortdetaljer: createStandardAction(
     MeldekortdetaljerTypeKeys.RESETT_MELDEKORTDETALJER
   )<void>(),
 };

--- a/src/app/actions/meldekortdetaljer.tsx
+++ b/src/app/actions/meldekortdetaljer.tsx
@@ -1,11 +1,17 @@
-import { ActionType, createAsyncAction } from 'typesafe-actions';
+import {
+  ActionType,
+  createAsyncAction,
+  createStandardAction,
+} from 'typesafe-actions';
 import { AxiosError } from 'axios';
 import { Meldekortdetaljer } from '../types/meldekort';
+import { AktivtMeldekortTypeKeys } from './aktivtMeldekort';
 
 export enum MeldekortdetaljerTypeKeys {
   HENT_MELDEKORTDETALJER = 'HENT_MELDEKORTDETALJER',
   HENT_MELDEKORTDETALJER_OK = 'HENT_MELDEKORTDETALJER_OK',
   HENT_MELDEKORTDETALJER_FEILET = 'HENT_MELDEKORTDETALJER_FEILET',
+  RESETT_MELDEKORTDETALJER = 'RESETT_MELDEKORTDETALJER',
 }
 
 export const MeldekortdetaljerActions = {
@@ -14,6 +20,9 @@ export const MeldekortdetaljerActions = {
     MeldekortdetaljerTypeKeys.HENT_MELDEKORTDETALJER_OK,
     MeldekortdetaljerTypeKeys.HENT_MELDEKORTDETALJER_FEILET
   )<void, Meldekortdetaljer, AxiosError>(),
+  resetMeldekortdetaljer: createStandardAction(
+    AktivtMeldekortTypeKeys.RESET_AKTIVT_MELDEKORT
+  )<void>(),
 };
 
 export type MeldekortdetaljerActionTypes = ActionType<

--- a/src/app/actions/meldekortdetaljer.tsx
+++ b/src/app/actions/meldekortdetaljer.tsx
@@ -5,7 +5,6 @@ import {
 } from 'typesafe-actions';
 import { AxiosError } from 'axios';
 import { Meldekortdetaljer } from '../types/meldekort';
-import { AktivtMeldekortTypeKeys } from './aktivtMeldekort';
 
 export enum MeldekortdetaljerTypeKeys {
   HENT_MELDEKORTDETALJER = 'HENT_MELDEKORTDETALJER',
@@ -21,7 +20,7 @@ export const MeldekortdetaljerActions = {
     MeldekortdetaljerTypeKeys.HENT_MELDEKORTDETALJER_FEILET
   )<void, Meldekortdetaljer, AxiosError>(),
   resetMeldekortdetaljer: createStandardAction(
-    AktivtMeldekortTypeKeys.RESET_AKTIVT_MELDEKORT
+    MeldekortdetaljerTypeKeys.RESETT_MELDEKORTDETALJER
   )<void>(),
 };
 

--- a/src/app/components/knapp/navKnapp.tsx
+++ b/src/app/components/knapp/navKnapp.tsx
@@ -19,6 +19,7 @@ interface MapStateToProps {
 
 interface MapDispatchToProps {
   leggTilAktivtMeldekort: (meldekort: Meldekort) => void;
+  resettAktivtMeldekort: () => void;
   settInnsendingstype: (innsendingstype: Innsendingstyper) => void;
   resetInnsending: () => void;
   leggTilMeldekortId: (meldekortId: number) => void;
@@ -80,6 +81,7 @@ class NavKnapp extends React.Component<Props> {
     } else {
       nesteAktivtMeldekort !== undefined &&
         nesteInnsendingstype !== undefined &&
+        this.props.resettAktivtMeldekort() &&
         this.props.leggTilAktivtMeldekort(nesteAktivtMeldekort);
 
       let validert: boolean = true;
@@ -159,6 +161,8 @@ const mapDispatchToProps = (dispatch: Dispatch): MapDispatchToProps => {
   return {
     leggTilAktivtMeldekort: (aktivtMeldekort: Meldekort) =>
       dispatch(AktivtMeldekortActions.oppdaterAktivtMeldekort(aktivtMeldekort)),
+    resettAktivtMeldekort: () =>
+      dispatch(AktivtMeldekortActions.resettAktivtMeldekort()),
     settInnsendingstype: (innsendingstype: Innsendingstyper) =>
       dispatch(InnsendingActions.leggTilInnsendingstype(innsendingstype)),
     resetInnsending: () => dispatch(InnsendingActions.resetInnsending()),

--- a/src/app/components/komponentlenke/komponentlenke.tsx
+++ b/src/app/components/komponentlenke/komponentlenke.tsx
@@ -21,7 +21,7 @@ interface MapStateToProps {
 }
 
 interface MapDispatcherToProps {
-  resetAktivtMeldekort: () => void;
+  resettAktivtMeldekort: () => void;
   leggTilAktivtMeldekort: (meldekort: Meldekort) => void;
 }
 
@@ -29,10 +29,9 @@ type ReduxType = KomponentlenkeProps & MapDispatcherToProps & MapStateToProps;
 
 class Komponentlenke extends React.Component<ReduxType> {
   clickHandler = () => {
+    this.props.resettAktivtMeldekort();
     if (this.props.meldekort) {
       this.props.leggTilAktivtMeldekort(this.props.meldekort);
-    } else {
-      this.props.resetAktivtMeldekort();
     }
 
     const pathname = this.props.router.location.pathname;
@@ -62,8 +61,8 @@ const mapDispatcherToProps = (dispatch: Dispatch): MapDispatcherToProps => {
   return {
     leggTilAktivtMeldekort: (aktivtMeldekort: Meldekort) =>
       dispatch(AktivtMeldekortActions.oppdaterAktivtMeldekort(aktivtMeldekort)),
-    resetAktivtMeldekort: () =>
-      dispatch(AktivtMeldekortActions.resetAktivtMeldekort()),
+    resettAktivtMeldekort: () =>
+      dispatch(AktivtMeldekortActions.resettAktivtMeldekort()),
   };
 };
 

--- a/src/app/components/komponentlenke/komponentlenke.tsx
+++ b/src/app/components/komponentlenke/komponentlenke.tsx
@@ -29,9 +29,10 @@ type ReduxType = KomponentlenkeProps & MapDispatcherToProps & MapStateToProps;
 
 class Komponentlenke extends React.Component<ReduxType> {
   clickHandler = () => {
-    this.props.resetAktivtMeldekort();
     if (this.props.meldekort) {
       this.props.leggTilAktivtMeldekort(this.props.meldekort);
+    } else {
+      this.props.resetAktivtMeldekort();
     }
 
     const pathname = this.props.router.location.pathname;

--- a/src/app/mock/responses/meldekortdetaljer.json
+++ b/src/app/mock/responses/meldekortdetaljer.json
@@ -1,7 +1,7 @@
 {
   "personId": 123456,
   "fodselsnr": "11111111111",
-  "meldekortId": 1011121314,
+  "meldekortId": 1111111111,
   "meldeperiode": "201851",
   "arkivnokkel": "1-ELEKTRONISK",
   "kortType": "ELEKTRONISK",

--- a/src/app/reducers/aktivtMeldekortReducer.tsx
+++ b/src/app/reducers/aktivtMeldekortReducer.tsx
@@ -35,7 +35,7 @@ const aktivtMeldekortReducer = (
     case getType(AktivtMeldekortActions.oppdaterAktivtMeldekort):
       return { ...state, ...action.payload };
 
-    case getType(AktivtMeldekortActions.resetAktivtMeldekort):
+    case getType(AktivtMeldekortActions.resettAktivtMeldekort):
       return { ...initialState };
 
     default:

--- a/src/app/reducers/meldekortdetaljerReducer.tsx
+++ b/src/app/reducers/meldekortdetaljerReducer.tsx
@@ -40,6 +40,8 @@ const meldekortdetaljerReducer = (
       return {
         meldekortdetaljer: action.payload,
       };
+    case getType(MeldekortdetaljerActions.resetMeldekortdetaljer):
+      return { ...initialState };
 
     default:
       return state;

--- a/src/app/reducers/meldekortdetaljerReducer.tsx
+++ b/src/app/reducers/meldekortdetaljerReducer.tsx
@@ -40,7 +40,7 @@ const meldekortdetaljerReducer = (
       return {
         meldekortdetaljer: action.payload,
       };
-    case getType(MeldekortdetaljerActions.resetMeldekortdetaljer):
+    case getType(MeldekortdetaljerActions.resettMeldekortdetaljer):
       return { ...initialState };
 
     default:

--- a/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
+++ b/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
@@ -28,8 +28,11 @@ import MobilTabell from '../../../components/tabell/mobil/mobilTabell';
 import { PersonInfoActions } from '../../../actions/personInfo';
 import { PersonInfo } from '../../../types/person';
 import classNames from 'classnames';
+import { AktivtMeldekortActions } from '../../../actions/aktivtMeldekort';
+import { HistoriskeMeldekortState } from '../../../reducers/historiskeMeldekortReducer';
 
 interface MapStateToProps {
+  historiskeMeldekort: HistoriskeMeldekortState;
   meldekortdetaljer: MeldekortdetaljerState;
   aktivtMeldekort: Meldekort;
   router: Router;
@@ -40,6 +43,7 @@ interface MapDispatchToProps {
   hentMeldekortdetaljer: () => void;
   resettMeldekortdetaljer: () => void;
   hentPersonInfo: () => void;
+  resettAktivtMeldekort: () => void;
 }
 
 type Props = MapDispatchToProps & MapStateToProps;
@@ -63,12 +67,16 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
   };
 
   sjekkAktivtMeldekortOgRedirect = () => {
-    if (this.props.aktivtMeldekort.meldekortId === 0) {
-      const pathname = this.props.router.location.pathname;
-      const tidligereMeldekort = '/tidligere-meldekort';
-      pathname !== tidligereMeldekort && history.push(tidligereMeldekort);
-    } else {
+    const { historiskeMeldekort, aktivtMeldekort } = this.props;
+    if (
+      aktivtMeldekort.meldekortId !== 0 &&
+      historiskeMeldekort.historiskeMeldekort.filter(
+        mk => mk.meldekortId === aktivtMeldekort.meldekortId
+      ).length > 0
+    ) {
       this.props.hentMeldekortdetaljer();
+    } else {
+      history.push('/tidligere-meldekort');
     }
   };
 
@@ -79,6 +87,11 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
     if (this.props.personInfo.personId === 0) {
       this.props.hentPersonInfo();
     }
+  }
+
+  componentWillUnmount(): void {
+    this.props.resettMeldekortdetaljer();
+    this.props.resettAktivtMeldekort();
   }
 
   handleWindowSize = () =>
@@ -206,6 +219,7 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
 
 const mapStateToProps = (state: RootState): MapStateToProps => {
   return {
+    historiskeMeldekort: state.historiskeMeldekort,
     meldekortdetaljer: state.meldekortdetaljer,
     aktivtMeldekort: state.aktivtMeldekort,
     router: selectRouter(state),
@@ -218,8 +232,10 @@ const mapDispatchToProps = (dispatch: Dispatch): MapDispatchToProps => {
     hentMeldekortdetaljer: () =>
       dispatch(MeldekortdetaljerActions.hentMeldekortdetaljer.request()),
     resettMeldekortdetaljer: () =>
-      dispatch(MeldekortdetaljerActions.resetMeldekortdetaljer()),
+      dispatch(MeldekortdetaljerActions.resettMeldekortdetaljer()),
     hentPersonInfo: () => dispatch(PersonInfoActions.hentPersonInfo.request()),
+    resettAktivtMeldekort: () =>
+      dispatch(AktivtMeldekortActions.resettAktivtMeldekort()),
   };
 };
 

--- a/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
+++ b/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
@@ -38,6 +38,7 @@ interface MapStateToProps {
 
 interface MapDispatchToProps {
   hentMeldekortdetaljer: () => void;
+  resettMeldekortdetaljer: () => void;
   hentPersonInfo: () => void;
 }
 
@@ -63,15 +64,25 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
 
   sjekkAktivtMeldekortOgRedirect = () => {
     if (this.props.aktivtMeldekort.meldekortId === 0) {
+      console.log('aktivt medlekortid er null. Redirecter');
+      // console.log('aktivt meldekortid: ', this.props.aktivtMeldekort.meldekortId);
       const pathname = this.props.router.location.pathname;
       const tidligereMeldekort = '/tidligere-meldekort';
       pathname !== tidligereMeldekort && history.push(tidligereMeldekort);
+    } else {
+      console.log('Aktivt meldekortid er ikke null. Henter medlekortdetaljer');
+      console.log(
+        'aktivt meldekortid: ',
+        this.props.aktivtMeldekort.meldekortId
+      );
+      this.props.hentMeldekortdetaljer();
     }
   };
 
   componentDidMount() {
+    console.log('Resetter meldekortdetaljer');
+    this.props.resettMeldekortdetaljer();
     this.sjekkAktivtMeldekortOgRedirect();
-    this.props.hentMeldekortdetaljer();
     window.addEventListener('resize', this.handleWindowSize);
     if (this.props.personInfo.personId === 0) {
       this.props.hentPersonInfo();
@@ -83,8 +94,31 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
       windowSize: window.innerWidth,
     });
 
+  samstemmMeldekortId = () => {
+    console.log('Samstemmer');
+    const { meldekortdetaljer, aktivtMeldekort } = this.props;
+    if (meldekortdetaljer.meldekortdetaljer.id !== '') {
+      console.log('Meldekortdetaljer.id er ikke tom!');
+      if (
+        aktivtMeldekort.meldekortId !==
+        meldekortdetaljer.meldekortdetaljer.meldekortId
+      ) {
+        console.log(
+          'Aktivt meldekortid er ikke lik som meldekortdetaljer.meldekortid. Redirecter.'
+        );
+        console.log('aktivt meldekortid: ', aktivtMeldekort.meldekortId);
+        console.log(
+          'meldekortdetaljer meldekortid: ',
+          meldekortdetaljer.meldekortdetaljer.meldekortId
+        );
+        history.push('/tidligere-meldekort');
+      }
+    }
+  };
+
   innhold = () => {
     const { meldekortdetaljer, aktivtMeldekort } = this.props;
+    this.samstemmMeldekortId();
     const rows = this.settTabellrader(aktivtMeldekort);
     const columns = [
       {
@@ -201,6 +235,8 @@ const mapDispatchToProps = (dispatch: Dispatch): MapDispatchToProps => {
   return {
     hentMeldekortdetaljer: () =>
       dispatch(MeldekortdetaljerActions.hentMeldekortdetaljer.request()),
+    resettMeldekortdetaljer: () =>
+      dispatch(MeldekortdetaljerActions.resetMeldekortdetaljer()),
     hentPersonInfo: () => dispatch(PersonInfoActions.hentPersonInfo.request()),
   };
 };

--- a/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
+++ b/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
@@ -64,23 +64,15 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
 
   sjekkAktivtMeldekortOgRedirect = () => {
     if (this.props.aktivtMeldekort.meldekortId === 0) {
-      console.log('aktivt medlekortid er null. Redirecter');
-      // console.log('aktivt meldekortid: ', this.props.aktivtMeldekort.meldekortId);
       const pathname = this.props.router.location.pathname;
       const tidligereMeldekort = '/tidligere-meldekort';
       pathname !== tidligereMeldekort && history.push(tidligereMeldekort);
     } else {
-      console.log('Aktivt meldekortid er ikke null. Henter medlekortdetaljer');
-      console.log(
-        'aktivt meldekortid: ',
-        this.props.aktivtMeldekort.meldekortId
-      );
       this.props.hentMeldekortdetaljer();
     }
   };
 
   componentDidMount() {
-    console.log('Resetter meldekortdetaljer');
     this.props.resettMeldekortdetaljer();
     this.sjekkAktivtMeldekortOgRedirect();
     window.addEventListener('resize', this.handleWindowSize);
@@ -95,22 +87,12 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
     });
 
   samstemmMeldekortId = () => {
-    console.log('Samstemmer');
     const { meldekortdetaljer, aktivtMeldekort } = this.props;
     if (meldekortdetaljer.meldekortdetaljer.id !== '') {
-      console.log('Meldekortdetaljer.id er ikke tom!');
       if (
         aktivtMeldekort.meldekortId !==
         meldekortdetaljer.meldekortdetaljer.meldekortId
       ) {
-        console.log(
-          'Aktivt meldekortid er ikke lik som meldekortdetaljer.meldekortid. Redirecter.'
-        );
-        console.log('aktivt meldekortid: ', aktivtMeldekort.meldekortId);
-        console.log(
-          'meldekortdetaljer meldekortid: ',
-          meldekortdetaljer.meldekortdetaljer.meldekortId
-        );
         history.push('/tidligere-meldekort');
       }
     }

--- a/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
+++ b/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
@@ -89,11 +89,6 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
     }
   }
 
-  componentWillUnmount(): void {
-    this.props.resettMeldekortdetaljer();
-    this.props.resettAktivtMeldekort();
-  }
-
   handleWindowSize = () =>
     this.setState({
       windowSize: window.innerWidth,

--- a/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
+++ b/src/app/sider/tidligereMeldekort/detaljer/detaljer.tsx
@@ -70,8 +70,8 @@ class Detaljer extends React.Component<Props, { windowSize: number }> {
   };
 
   componentDidMount() {
-    this.props.hentMeldekortdetaljer();
     this.sjekkAktivtMeldekortOgRedirect();
+    this.props.hentMeldekortdetaljer();
     window.addEventListener('resize', this.handleWindowSize);
     if (this.props.personInfo.personId === 0) {
       this.props.hentPersonInfo();


### PR DESCRIPTION
Endrer litt på hvordan vi validerer et meldekort før vi henter meldekortdetaljer.
Endringen innebærer at vi sjekker at aktivt meldekort finnes og at meldekortid'en til aktivt meldekort tilsvarer en meldekortid fra tidligere meldekort. I tillegg vil aktivt meldekort og meldekortdetaljer settes til initial state når man går ut fra detalj-siden.