### PR TITLE
Amplitude metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,25 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@amplitude/types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/types/-/types-1.3.1.tgz",
+      "integrity": "sha512-YMANufwc3c0T7EGn6Nk8L2UwdLpZoqRFu+9f5EGrn2cReM2WdTZC1q2Dl9JLwZkdTE6mknjpOhW5c5ffC1n9LQ=="
+    },
+    "@amplitude/ua-parser-js": {
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+      "integrity": "sha512-VbQuJymJ20WEw0HtI2np7EdC3NJGUWi8+Xdbc7uk8WfMIF308T0howpzkQ3JFMN7ejnrcSM/OyNGveeE3TP3TA=="
+    },
+    "@amplitude/utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.3.1.tgz",
+      "integrity": "sha512-PzlQhR2wvr31Qxb7+Ua+EZi4SUn2VBBiur6MD4B/1oIxx4+0dFlecdzh1BL+XG+T86dMX46g3PMGyk2OStVDQw==",
+      "requires": {
+        "@amplitude/types": "^1.3.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -1989,6 +2008,12 @@
         "defer-to-connect": "^2.0.0"
       }
     },
+    "@types/amplitude-js": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/amplitude-js/-/amplitude-js-7.0.1.tgz",
+      "integrity": "sha512-xrmhX39GoSBIuOOPWYL5uvVLn6a5Cvea0wb6SkJNW9+2w5GCK6hT0vvMaH1GaaeSqvb1QFjHNsEgXuyQqML0sw==",
+      "dev": true
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -2896,6 +2921,29 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "optional": true
+    },
+    "amplitude-js": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/amplitude-js/-/amplitude-js-7.4.1.tgz",
+      "integrity": "sha512-AiqYt9z0tzWBxcE0ILVDNOksXuPdZa4Jiak2VSWwBpgt+CUJ4jZzT3daGZPbw50o2/KnSIfMfAojcT7PpmKxLA==",
+      "requires": {
+        "@amplitude/ua-parser-js": "0.7.24",
+        "@amplitude/utils": "^1.0.5",
+        "blueimp-md5": "^2.10.0",
+        "query-string": "5"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        }
+      }
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -3885,6 +3933,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -3910,6 +3967,11 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "blueimp-md5": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+      "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
     },
     "bn.js": {
       "version": "5.1.3",
@@ -10815,7 +10877,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         }
       }
     },
@@ -12933,6 +12999,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -21228,7 +21300,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -21586,7 +21662,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/redux-logger": "^3.0.7",
     "@types/redux-persist": "^4.3.1",
     "@types/redux-persist-transform-encrypt": "^2.0.1",
+    "amplitude-js": "7.4.1",
     "axios": "^0.21.1",
     "babel-polyfill": "^6.26.0",
     "babel-runtime": "^6.26.0",
@@ -121,6 +122,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
+    "@types/amplitude-js": "7.0.1",
     "@types/enzyme": "^3.10.2",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/jest": "24.0.15",

--- a/src/app/sider/etterregistrerMeldekort/etterregistrerMeldekort.tsx
+++ b/src/app/sider/etterregistrerMeldekort/etterregistrerMeldekort.tsx
@@ -19,6 +19,7 @@ import {
 import NavFrontendSpinner from 'nav-frontend-spinner';
 import { useEffect } from 'react';
 import EtterregistreringInnhold from './etterregistreringInnhold';
+import { loggAktivitet } from '../../utils/amplitudeUtils';
 
 interface MapStateToProps {
   person: Person;
@@ -65,6 +66,7 @@ function EtterregistrerMeldekort({
       resetInnsending();
     }
     hentPerson();
+    loggAktivitet('Viser etterregistrere meldekort');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/app/sider/innsending/1-sporsmalsside/sporsmalsside.tsx
+++ b/src/app/sider/innsending/1-sporsmalsside/sporsmalsside.tsx
@@ -34,6 +34,7 @@ import { Sporsmal } from './sporsmal/sporsmalConfig';
 import { UiActions } from '../../../actions/ui';
 import { erAktivtMeldekortGyldig } from '../../../utils/meldekortUtils';
 import { MeldekortActions } from '../../../actions/meldekort';
+import { loggAktivitet } from '../../../utils/amplitudeUtils';
 
 interface MapStateToProps {
   aktivtMeldekort: Meldekort;
@@ -340,6 +341,7 @@ class Sporsmalsside extends React.Component<SporsmalssideProps, any> {
       );
       this.props.oppdaterSvar(nySporsmalsobjektState);
     }
+    loggAktivitet('Viser spørsmål');
   }
 
   render() {
@@ -477,7 +479,4 @@ const mapDispatcherToProps = (dispatch: Dispatch): MapDispatchToProps => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatcherToProps
-)(Sporsmalsside);
+export default connect(mapStateToProps, mapDispatcherToProps)(Sporsmalsside);

--- a/src/app/sider/innsending/2-utfyllingsside/utfyllingsside.tsx
+++ b/src/app/sider/innsending/2-utfyllingsside/utfyllingsside.tsx
@@ -32,6 +32,7 @@ import { InnsendingActions } from '../../../actions/innsending';
 import { erAktivtMeldekortGyldig } from '../../../utils/meldekortUtils';
 import { Redirect } from 'react-router';
 import { FravaerTypeEnum } from '../../../types/meldekort';
+import { loggAktivitet } from '../../../utils/amplitudeUtils';
 
 interface MapStateToProps {
   innsending: InnsendingState;
@@ -68,6 +69,7 @@ class Utfyllingsside extends React.Component<
 
   componentDidMount() {
     scrollTilElement(undefined, 'auto');
+    loggAktivitet('Viser utfylling');
   }
 
   hentSporsmal = (): SpmSvar[] => {

--- a/src/app/sider/innsending/3-bekreftelsesside/bekreftelse.tsx
+++ b/src/app/sider/innsending/3-bekreftelsesside/bekreftelse.tsx
@@ -34,6 +34,7 @@ import { selectFeilmelding } from '../../../selectors/ui';
 import { BaksystemFeilmelding } from '../../../types/ui';
 import { UiActions } from '../../../actions/ui';
 import { UtfyltDag } from '../2-utfyllingsside/utfylling/utfyltDagConfig';
+import { loggAktivitet } from '../../../utils/amplitudeUtils';
 
 interface MapStateToProps {
   innsending: InnsendingState;
@@ -74,6 +75,7 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
 
   componentDidMount() {
     scrollTilElement(undefined, 'auto');
+    loggAktivitet('Viser bekreftelse');
   }
 
   konverterInnsendingTilMeldekortdetaljer = (): MeldekortdetaljerState => {

--- a/src/app/sider/innsending/4-kvitteringsside/kvittering.tsx
+++ b/src/app/sider/innsending/4-kvitteringsside/kvittering.tsx
@@ -37,6 +37,7 @@ import { MeldekortActions } from '../../../actions/meldekort';
 import { erMeldekortSendtInnTidligere } from '../../../utils/meldekortUtils';
 import { PersonInfoActions } from '../../../actions/personInfo';
 import NavFrontendSpinner from 'nav-frontend-spinner';
+import { loggAktivitet } from '../../../utils/amplitudeUtils';
 
 interface MapStateToProps {
   router: Router;
@@ -76,6 +77,7 @@ class Kvittering extends React.Component<KvitteringsProps> {
     this.props.leggTilInnsendtMeldekort(
       oppdatertSendteMeldekort.sendteMeldekort
     );
+    loggAktivitet('Viser kvittering');
   }
 
   returnerMeldekortListaMedFlereMeldekortIgjen = (

--- a/src/app/sider/ofteStilteSporsmal/ofteStilteSporsmal.tsx
+++ b/src/app/sider/ofteStilteSporsmal/ofteStilteSporsmal.tsx
@@ -9,6 +9,7 @@ import sporrende from '../../ikoner/sporrende.svg';
 import { InnsendingActions } from '../../actions/innsending';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
+import { loggAktivitet } from '../../utils/amplitudeUtils';
 
 interface SporsmalProps {
   overskriftId: string;
@@ -77,6 +78,7 @@ class OfteStilteSporsmal extends React.Component<
 
   componentDidMount() {
     this.props.resetInnsending();
+    loggAktivitet('Viser ofte stilte spørsmål');
   }
 
   render() {
@@ -116,7 +118,4 @@ const mapDispatchToProps = (dispatch: Dispatch): MapDispatchToProps => {
   };
 };
 
-export default connect(
-  null,
-  mapDispatchToProps
-)(OfteStilteSporsmal);
+export default connect(null, mapDispatchToProps)(OfteStilteSporsmal);

--- a/src/app/sider/omMeldekort/omMeldekort.tsx
+++ b/src/app/sider/omMeldekort/omMeldekort.tsx
@@ -15,6 +15,7 @@ import { Router } from '../../types/router';
 import { RootState } from '../../store/configureStore';
 import { selectRouter } from '../../selectors/router';
 import { scrollTilElement } from '../../utils/scroll';
+import { loggAktivitet } from '../../utils/amplitudeUtils';
 
 interface MapStateToProps {
   router: Router;
@@ -40,6 +41,7 @@ class OmMeldekort extends React.Component<
     if (typeof valgtMenyPunkt !== 'undefined') {
       settValgtMenyPunkt(valgtMenyPunkt);
     }
+    loggAktivitet('Viser om meldekort');
   }
 
   render() {
@@ -109,7 +111,4 @@ const mapDispatchToProps = (dispatch: Dispatch): MapDispatchToProps => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(OmMeldekort);
+export default connect(mapStateToProps, mapDispatchToProps)(OmMeldekort);

--- a/src/app/sider/sendMeldekort/sendMeldekort.tsx
+++ b/src/app/sider/sendMeldekort/sendMeldekort.tsx
@@ -26,6 +26,7 @@ import {
 import { useEffect } from 'react';
 import MeldingOmMeldekortSomIkkeErKlare from './meldingOmIkkeKlareMeldekort';
 import SendMeldekortInnhold from './sendMeldekortInnhold';
+import { loggAktivitet } from '../../utils/amplitudeUtils';
 
 interface MapStateToProps {
   person: Person;
@@ -108,6 +109,8 @@ function SendMeldekort({
       resetInnsending();
     }
     hentPerson();
+
+    loggAktivitet('Viser send');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -162,7 +165,4 @@ const mapDispatchToProps = (dispatch: Dispatch): MapDispatchToProps => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(SendMeldekort);
+export default connect(mapStateToProps, mapDispatchToProps)(SendMeldekort);

--- a/src/app/sider/tidligereMeldekort/tidligereMeldekort.tsx
+++ b/src/app/sider/tidligereMeldekort/tidligereMeldekort.tsx
@@ -39,6 +39,7 @@ import { WeblogicActions } from '../../actions/weblogic';
 import { WeblogicPing } from '../../types/weblogic';
 import WeblogicErNedeInfomelding from '../../components/feil/weblogicErNedeInfomelding';
 import { scrollTilElement } from '../../utils/scroll';
+import { loggAktivitet } from '../../utils/amplitudeUtils';
 
 interface MapStateToProps {
   historiskeMeldekort: HistoriskeMeldekortState;
@@ -193,6 +194,7 @@ class TidligereMeldekort extends React.Component<Props, State> {
       this.props.settValgtMenyPunkt(valgtMenyPunkt);
     }
     window.addEventListener('resize', this.handleWindowSize);
+    loggAktivitet('Viser tidligere meldekort');
   }
 
   tekstOgContent = () => {

--- a/src/app/utils/amplitudeUtils.tsx
+++ b/src/app/utils/amplitudeUtils.tsx
@@ -1,0 +1,47 @@
+import amplitude from 'amplitude-js';
+import Environment from './env';
+
+let initialized = false;
+
+function initAmplitude() {
+  const { amplitudeKey, amplitudeUrl } = Environment();
+
+  if (!amplitudeKey || !amplitudeUrl) {
+    return;
+  }
+
+  const config = {
+    apiEndpoint: amplitudeUrl,
+    saveEvents: true,
+    includeUtm: true,
+    includeReferrer: true,
+    trackingOptions: {
+      city: false,
+      ip_address: false,
+    },
+  };
+  amplitude.getInstance().init(amplitudeKey, undefined, config);
+  initialized = true;
+}
+
+initAmplitude();
+
+function amplitudeLogger(name: string, values?: object) {
+  if (!initialized) {
+    console.log('Aktivitet uten initialisert amplitude:', name, values);
+    return;
+  }
+  amplitude.getInstance().logEvent(name, values);
+}
+
+type AmplitudeAktivitetsData = {
+  aktivitet: string;
+};
+
+export function loggAktivitet(
+  aktivitet: string,
+  data?: AmplitudeAktivitetsData
+) {
+  const eventData = { ...data, aktivitet: aktivitet };
+  amplitudeLogger('meldekort.aktivitet', eventData);
+}

--- a/src/app/utils/env.tsx
+++ b/src/app/utils/env.tsx
@@ -10,6 +10,8 @@ const Environment = () => {
         'https://loginservice-b2clogin-sbs.dev.nav.no/login?level=Level3',
       // loginUrl: 'https://loginservice-q.nav.no/login?level=Level3',
       logoutUrl: 'https://loginservice-q.nav.no/slo',
+      amplitudeUrl: 'amplitude.nav.no/collect',
+      amplitudeKey: '2f190e67f31d7e4719c5ff048ad3d3e6',
     };
   } else if (window.location.hostname.indexOf('www-q1.nav.no') > -1) {
     return {
@@ -19,6 +21,8 @@ const Environment = () => {
         'https://loginservice-b2clogin-sbs.dev.nav.no/login?level=Level3',
       // loginUrl: 'https://loginservice-q.nav.no/login?level=Level3',
       logoutUrl: 'https://loginservice-q.nav.no/slo',
+      amplitudeUrl: 'amplitude.nav.no/collect',
+      amplitudeKey: '2f190e67f31d7e4719c5ff048ad3d3e6',
     };
   } else if (erMock()) {
     return {
@@ -40,6 +44,8 @@ const Environment = () => {
     apiUrl: 'https://www.nav.no/meldekort/meldekort-api/api/',
     loginUrl: 'https://loginservice.nav.no/login?level=Level3',
     logoutUrl: 'https://loginservice.nav.no/slo',
+    amplitudeUrl: 'amplitude.nav.no/collect',
+    amplitudeKey: 'b0bccdd4dd75081606ef7bcab668a7ed',
   };
 };
 


### PR DESCRIPTION
Målet med endringen er å måle aktivitet i Meldekort-tjenesten som kan korreleres med annen måling, slik at vi får et bedre og mer fullstendig bilde av brukeroppførsel.

For eksempel ønsker vi å måle hvor mange personer som går inn og fyller ut meldekort fra inngangen på Ditt NAV, sammenlignet med antall personer som går direkte inn til Meldekort.

Dette løses ved å legge inn amplitude-målinger for følgende aktiviteter:
* **Viser send** (oversikt over meldekort til innsending)
* Viser ofte stilte spørsmål
* Viser etterregistrere meldekort
* Viser om meldekort
* **Viser spørsmål**
* Viser utfylling
* Viser bekreftelse
* **Viser kvittering**

(Vi anser de uthevede som mest nyttig)

---

Amplitude-aktivitetene kommer inn med nøkkel `meldekort.aktivitet`, med `aktivitet`-attributtet satt til handlingen fra listen over. Dette er gjort for å følge formatet til Amplitude-målingene vi gjør i Team Paw, for eksempel i [Veientilarbeid](https://github.com/navikt/veientilarbeid).

Nøklene som er lagt inn peker mot «PO Arbeid – test» og «PO Arbeid – prod» i hhv. q0/q1 og prod. Dette lar oss enklere måle på tvers, mot applikasjonene i PO Arbeid (f.eks. Veientilarbeid på Ditt NAV). På sikt er det muligens mer hensiktsmessig å enten gå over til et fellesprosjekt, eller sette opp et eget prosjekt.