### PR TITLE
Sender med informasjon om besvarelsen til Amplitude på kvitteringssiden

### DIFF
--- a/src/app/sider/innsending/4-kvitteringsside/kvittering.tsx
+++ b/src/app/sider/innsending/4-kvitteringsside/kvittering.tsx
@@ -77,7 +77,14 @@ class Kvittering extends React.Component<KvitteringsProps> {
     this.props.leggTilInnsendtMeldekort(
       oppdatertSendteMeldekort.sendteMeldekort
     );
-    loggAktivitet('Viser kvittering');
+
+    const arbeidsssokerSvar = this.props.innsending?.meldekortdetaljer?.sporsmal
+      ?.arbeidssoker;
+    loggAktivitet('Viser kvittering', {
+      arbeidssoker: arbeidsssokerSvar ? 'ja' : 'nei',
+      meldegruppe: this.props.aktivtMeldekort?.meldegruppe || 'UKJENT',
+      innsendingstype: this.props.innsendingstype || 'UKJENT',
+    });
   }
 
   returnerMeldekortListaMedFlereMeldekortIgjen = (

--- a/src/app/utils/amplitudeUtils.tsx
+++ b/src/app/utils/amplitudeUtils.tsx
@@ -35,7 +35,9 @@ function amplitudeLogger(name: string, values?: object) {
 }
 
 type AmplitudeAktivitetsData = {
-  aktivitet: string;
+  arbeidssoker: string;
+  meldegruppe: string;
+  innsendingstype: string;
 };
 
 export function loggAktivitet(


### PR DESCRIPTION
Vi i PO Arbeid jobber en del med å forhindre tap av dagpenger ved feilaktig inaktivering, gjerne på grunn av glemt meldekort. I den forbindelse ønsker vi å se nærmere på hvordan brukere oppfører seg på tvers av de relevante løsningene (Arbeidssøkerregistrering, Ditt NAV / Veien til arbeid, Meldekort, m.m.)

Et viktig poeng er å vite når personer aktivt «avslutter» forholdet sitt til NAV, slik at vi kan se bort fra dem i statistikken. Vi kan hente ut dette fra DVH, men koblingen til de andre systemene med tanke på brukeroppførsel mangler. Det kan vi få ved å sende hendelsen «Velger å ikke lenger stå som arbeidssøker» fra Meldekort-løsningen til Amplitude.

---

Konkret lar denne PRen oss se hvem som velger «Nei» på spørsmålet om å forbli registrert som arbeidssøker.
Koblet opp mot resten av Amplitude-verdiene, kan vi med dette få tydeligere måling på «bevisst utgang» fra NAV-systemet.

`innsendingstype` gjør det mulig å filtrere vekk etterregistreringer og korrigeringer fra «vanlige» innsendinger.
`meldegruppe` lar oss ytterligere filtrere målingene til de meste relevange gruppene for PO Arbeid: `DAGP` og `ARBS`.
Det er ingen informasjon om personen i seg selv utover disse datapunktene.

