### PR TITLE
Mp 394 loginservice

### DIFF
--- a/.nais/vars-q0.yaml
+++ b/.nais/vars-q0.yaml
@@ -3,5 +3,4 @@ slackAlertChannel: team-meldeplikt-alerts-dev
 ingresses:
   - "https://meldekort-q0.dev.nav.no"
   - "https://meldekort-q0.nais.oera-q.local"
-  - "https://www-q0.nav.no/meldekort"
   - "https://www-q0.dev.nav.no/meldekort"

--- a/.nais/vars-q0.yaml
+++ b/.nais/vars-q0.yaml
@@ -4,3 +4,4 @@ ingresses:
   - "https://meldekort-q0.dev.nav.no"
   - "https://meldekort-q0.nais.oera-q.local"
   - "https://www-q0.nav.no/meldekort"
+  - "https://www-q0.dev.nav.no/meldekort"

--- a/.nais/vars-q1.yaml
+++ b/.nais/vars-q1.yaml
@@ -4,3 +4,4 @@ ingresses:
   - "https://meldekort-q1.dev.nav.no"
   - "https://meldekort-q1.nais.oera-q.local"
   - "https://www-q1.nav.no/meldekort"
+  - "https://www-q1.dev.nav.no/meldekort"

--- a/.nais/vars-q1.yaml
+++ b/.nais/vars-q1.yaml
@@ -3,5 +3,4 @@ slackAlertChannel: team-meldeplikt-alerts-dev
 ingresses:
   - "https://meldekort-q1.dev.nav.no"
   - "https://meldekort-q1.nais.oera-q.local"
-  - "https://www-q1.nav.no/meldekort"
   - "https://www-q1.dev.nav.no/meldekort"

--- a/src/app/utils/env.tsx
+++ b/src/app/utils/env.tsx
@@ -6,8 +6,8 @@ const Environment = () => {
     return {
       dittNavUrl: 'https://www-q0.nav.no/person/dittnav',
       apiUrl: 'https://www-q0.nav.no/meldekort/meldekort-api/api/',
-      loginUrl: 'https://loginservice-q.nav.no/login?level=Level3',
-      logoutUrl: 'https://loginservice-q.nav.no/slo',
+      loginUrl: 'https://loginservice.dev.nav.no/login?level=Level3',
+      logoutUrl: 'https://loginservice.dev.nav.no/slo',
       amplitudeUrl: 'amplitude.nav.no/collect',
       amplitudeKey: '2f190e67f31d7e4719c5ff048ad3d3e6',
     };
@@ -15,8 +15,8 @@ const Environment = () => {
     return {
       dittNavUrl: 'https://www-q1.nav.no/person/dittnav',
       apiUrl: 'https://www-q1.nav.no/meldekort/meldekort-api/api/',
-      loginUrl: 'https://loginservice-q.nav.no/login?level=Level3',
-      logoutUrl: 'https://loginservice-q.nav.no/slo',
+      loginUrl: 'https://loginservice.dev.nav.no/login?level=Level3',
+      logoutUrl: 'https://loginservice.dev.nav.no/slo',
       amplitudeUrl: 'amplitude.nav.no/collect',
       amplitudeKey: '2f190e67f31d7e4719c5ff048ad3d3e6',
     };
@@ -24,15 +24,15 @@ const Environment = () => {
     return {
       dittNavUrl: 'https://www.nav.no/person/dittnav',
       apiUrl: '',
-      loginUrl: 'https://loginservice-q.nav.no/login?level=Level3',
-      logoutUrl: 'https://loginservice-q.nav.no/slo',
+      loginUrl: 'https://loginservice.dev.nav.no/login?level=Level3',
+      logoutUrl: 'https://loginservice.dev.nav.no/slo',
     };
   } else if (erLocalhost()) {
     return {
       dittNavUrl: 'https://www.nav.no/person/dittnav',
       apiUrl: 'http://localhost:8801/meldekort/meldekort-api/api/',
-      loginUrl: 'https://loginservice-q.nav.no/login?level=Level3',
-      logoutUrl: 'https://loginservice-q.nav.no/slo',
+      loginUrl: 'https://loginservice.dev.nav.no/login?level=Level3',
+      logoutUrl: 'https://loginservice.dev.nav.no/slo',
     };
   }
   return {

--- a/src/app/utils/env.tsx
+++ b/src/app/utils/env.tsx
@@ -4,7 +4,7 @@ import { Konstanter } from './consts';
 const Environment = () => {
   if (window.location.hostname.indexOf('www-q0.dev.nav.no') > -1) {
     return {
-      dittNavUrl: 'https://www-q0.nav.no/person/dittnav',
+      dittNavUrl: 'https://www.dev.nav.no/person/dittnav',
       apiUrl: 'https://www-q0.dev.nav.no/meldekort/meldekort-api/api/',
       loginUrl: 'https://loginservice.dev.nav.no/login?level=Level3',
       logoutUrl: 'https://loginservice.dev.nav.no/slo',
@@ -13,7 +13,7 @@ const Environment = () => {
     };
   } else if (window.location.hostname.indexOf('www-q1.dev.nav.no') > -1) {
     return {
-      dittNavUrl: 'https://www-q1.nav.no/person/dittnav',
+      dittNavUrl: 'https://www.dev.nav.no/person/dittnav',
       apiUrl: 'https://www-q1.dev.nav.no/meldekort/meldekort-api/api/',
       loginUrl: 'https://loginservice.dev.nav.no/login?level=Level3',
       logoutUrl: 'https://loginservice.dev.nav.no/slo',
@@ -22,14 +22,14 @@ const Environment = () => {
     };
   } else if (erMock()) {
     return {
-      dittNavUrl: 'https://www.nav.no/person/dittnav',
+      dittNavUrl: 'https://www.dev.nav.no/person/dittnav',
       apiUrl: '',
       loginUrl: 'https://loginservice.dev.nav.no/login?level=Level3',
       logoutUrl: 'https://loginservice.dev.nav.no/slo',
     };
   } else if (erLocalhost()) {
     return {
-      dittNavUrl: 'https://www.nav.no/person/dittnav',
+      dittNavUrl: 'https://www.dev.nav.no/person/dittnav',
       apiUrl: 'http://localhost:8801/meldekort/meldekort-api/api/',
       loginUrl: 'https://loginservice.dev.nav.no/login?level=Level3',
       logoutUrl: 'https://loginservice.dev.nav.no/slo',

--- a/src/app/utils/env.tsx
+++ b/src/app/utils/env.tsx
@@ -2,7 +2,7 @@ import { erLocalhost, erMock } from '../mock/utils';
 import { Konstanter } from './consts';
 
 const Environment = () => {
-  if (window.location.hostname.indexOf('www-q0.nav.no') > -1) {
+  if (window.location.hostname.indexOf('www-q0.dev.nav.no') > -1) {
     return {
       dittNavUrl: 'https://www-q0.nav.no/person/dittnav',
       apiUrl: 'https://www-q0.nav.no/meldekort/meldekort-api/api/',
@@ -11,7 +11,7 @@ const Environment = () => {
       amplitudeUrl: 'amplitude.nav.no/collect',
       amplitudeKey: '2f190e67f31d7e4719c5ff048ad3d3e6',
     };
-  } else if (window.location.hostname.indexOf('www-q1.nav.no') > -1) {
+  } else if (window.location.hostname.indexOf('www-q1.dev.nav.no') > -1) {
     return {
       dittNavUrl: 'https://www-q1.nav.no/person/dittnav',
       apiUrl: 'https://www-q1.nav.no/meldekort/meldekort-api/api/',

--- a/src/app/utils/env.tsx
+++ b/src/app/utils/env.tsx
@@ -5,7 +5,7 @@ const Environment = () => {
   if (window.location.hostname.indexOf('www-q0.dev.nav.no') > -1) {
     return {
       dittNavUrl: 'https://www-q0.nav.no/person/dittnav',
-      apiUrl: 'https://www-q0.nav.no/meldekort/meldekort-api/api/',
+      apiUrl: 'https://www-q0.dev.nav.no/meldekort/meldekort-api/api/',
       loginUrl: 'https://loginservice.dev.nav.no/login?level=Level3',
       logoutUrl: 'https://loginservice.dev.nav.no/slo',
       amplitudeUrl: 'amplitude.nav.no/collect',
@@ -14,7 +14,7 @@ const Environment = () => {
   } else if (window.location.hostname.indexOf('www-q1.dev.nav.no') > -1) {
     return {
       dittNavUrl: 'https://www-q1.nav.no/person/dittnav',
-      apiUrl: 'https://www-q1.nav.no/meldekort/meldekort-api/api/',
+      apiUrl: 'https://www-q1.dev.nav.no/meldekort/meldekort-api/api/',
       loginUrl: 'https://loginservice.dev.nav.no/login?level=Level3',
       logoutUrl: 'https://loginservice.dev.nav.no/slo',
       amplitudeUrl: 'amplitude.nav.no/collect',


### PR DESCRIPTION
- loginservice-q finnes ikke lenger i SBS, vi må benytte loginservice.dev.nav.no fra GCP
- dekoratøren er flyttet til GCP -> endret i Vault: APPRES_CMS_URL=https://dekoratoren.ekstern.dev.nav.no
- endret til dev.nav.no ingresser, og whitelistet disse for loginservice clallback