### PR TITLE
MELDEPLIKT-319 CPU, memory

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -29,11 +29,11 @@ spec:
   webproxy: true
   resources:
     limits:
-      cpu: '3'
-      memory: 1024Mi
+      cpu: 50m
+      memory: 512Mi
     requests:
-      cpu: 500m
-      memory: 768Mi
+      cpu: 50m
+      memory: 512Mi
   envFrom:
     - secret: {{ appName }}{{ dashEnv }}
   env:

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -32,8 +32,8 @@ spec:
       cpu: 50m
       memory: 512Mi
     requests:
-      cpu: 50m
-      memory: 512Mi
+      cpu: 25m
+      memory: 256Mi
   envFrom:
     - secret: {{ appName }}{{ dashEnv }}
   env:

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -29,11 +29,11 @@ spec:
   webproxy: true
   resources:
     limits:
-      cpu: 50m
+      cpu: 75m
       memory: 512Mi
     requests:
-      cpu: 25m
-      memory: 256Mi
+      cpu: 50m
+      memory: 512Mi
   envFrom:
     - secret: {{ appName }}{{ dashEnv }}
   env:


### PR DESCRIPTION
```
PS C:\Users\S162778> kubectl top pod -n meldekort
NAME                                     CPU(cores)   MEMORY(bytes)
meldekort-frontend-769b6db6b9-hnwm7        26m          489Mi
meldekort-frontend-769b6db6b9-v7tpd        25m          483Mi
```

Dvs. limits 512 MiB og 50 mCPU er nok, men ikke for mye, synes jeg.