### PR TITLE
Legger til dagtall i fraværsperiodene for å unngå tidssonefeil

### DIFF
--- a/src/app/sider/innsending/3-bekreftelsesside/bekreftelse.tsx
+++ b/src/app/sider/innsending/3-bekreftelsesside/bekreftelse.tsx
@@ -174,6 +174,7 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
           dag: dato,
           type: { typeFravaer: FravaerTypeEnum.ARBEIDS_FRAVAER },
           arbeidTimer: meldekortDag.arbeidetTimerSum,
+          meldekortperiodeDag: meldekortDag.dag,
         });
       }
 
@@ -181,12 +182,14 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
         fravar.push({
           dag: dato,
           type: { typeFravaer: FravaerTypeEnum.SYKDOM },
+          meldekortperiodeDag: meldekortDag.dag,
         });
       }
       if (meldekortDag.kurs) {
         fravar.push({
           dag: dato,
           type: { typeFravaer: FravaerTypeEnum.KURS_UTDANNING },
+          meldekortperiodeDag: meldekortDag.dag,
         });
       }
 
@@ -194,6 +197,7 @@ class Bekreftelse extends React.Component<BekreftelseProps, DetaljerOgFeil> {
         fravar.push({
           dag: dato,
           type: { typeFravaer: FravaerTypeEnum.ANNET_FRAVAER },
+          meldekortperiodeDag: meldekortDag.dag,
         });
       }
     });

--- a/src/app/types/meldekort.tsx
+++ b/src/app/types/meldekort.tsx
@@ -65,6 +65,7 @@ export interface Fravaer {
   dag: Date;
   type: FravaerType;
   arbeidTimer?: number;
+  meldekortperiodeDag?: number;
 }
 
 export interface Sporsmalsobjekt {


### PR DESCRIPTION
I stedet for å sende dato, legger vi til et optional felt `meldekortperiodeDag` i responsen vi sender backenden. Da kan de finne ut av hvilken dag vi melder fra, og unngå alle tidssoneproblemer som vi vil få i frontenden.

@igorshuliakov @mkjeldsr er dette en OK måte å løse problematikken på?